### PR TITLE
fix: replace streaming json.Encoder with marshal-then-write pattern

### DIFF
--- a/nexus-broker/pkg/handlers/callback.go
+++ b/nexus-broker/pkg/handlers/callback.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/auth"
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/discovery"
+	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/httputil"
 	oidcutil "github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/oidc"
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/server"
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/vault"
@@ -300,8 +301,7 @@ func (h *CallbackHandler) GetCaptureSchema(w http.ResponseWriter, r *http.Reques
 		Schema:       schema,
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	httputil.WriteJSON(w, http.StatusOK, response)
 }
 
 // SaveCredential handles the submission of the credential capture form.
@@ -470,9 +470,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 		h.logAuditEvent(&connectionID, "token_retrieval_failed", map[string]string{"error": "connection not active", "status": connection.Status}, r)
 
 		if connection.Status == "attention" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusConflict)
-			json.NewEncoder(w).Encode(map[string]string{
+			httputil.WriteJSON(w, http.StatusConflict, map[string]string{
 				"error":  "attention_required",
 				"detail": "Connection requires attention. The user must re-authenticate.",
 			})
@@ -572,9 +570,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 	}
 	h.metricTokenGet.WithLabelValues(connection.ProviderID, hasID).Inc()
 
-	// Return the response
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(response)
+	httputil.WriteJSON(w, http.StatusOK, response)
 }
 
 // exchangeCodeForTokens exchanges authorization code for access tokens
@@ -754,9 +750,7 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 				h.logAuditEvent(&connectionID, "token_refresh_fatal", map[string]string{"error": err.Error(), "status_code": fmt.Sprintf("%d", statusCode)}, r)
 				h.updateConnectionStatus(connectionID, "attention")
 
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusConflict) // 409 Conflict is a good signal for "state issue"
-				json.NewEncoder(w).Encode(map[string]string{
+				httputil.WriteJSON(w, http.StatusConflict, map[string]string{
 					"error":  "attention_required",
 					"detail": "The connection credentials are invalid or expired and cannot be refreshed. User re-consent is required.",
 				})
@@ -772,8 +766,7 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Store refreshed token failed", http.StatusInternalServerError)
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(newTokens)
+		httputil.WriteJSON(w, http.StatusOK, newTokens)
 	default:
 		http.Error(w, "Unsupported provider auth_type", http.StatusInternalServerError)
 		return

--- a/nexus-broker/pkg/handlers/consent.go
+++ b/nexus-broker/pkg/handlers/consent.go
@@ -2,8 +2,8 @@ package handlers
 
 import (
 	"database/sql"
-	"fmt"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/auth"
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/discovery"
+	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/httputil"
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/server"
 )
 
@@ -182,8 +183,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 			ProviderID: request.ProviderID,
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		httputil.WriteJSON(w, http.StatusOK, response)
 	case "api_key", "basic_auth":
 		// Create Connection
 		connectionID := uuid.New()
@@ -226,8 +226,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 			ProviderID: request.ProviderID,
 		}
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(response)
+		httputil.WriteJSON(w, http.StatusOK, response)
 	default:
 		http.Error(w, "Unsupported provider auth_type", http.StatusBadRequest)
 		return
@@ -275,17 +274,17 @@ func (h *ConsentHandler) buildAuthURL(providerAuthURL, clientID, state, codeChal
 	q.Set("client_id", clientID)
 	q.Set("redirect_uri", baseURL+redirectPath)
 	q.Set("response_type", "code")
-	
+
 	if !skipScopeOnAuth {
 		if len(scopes) > 0 {
 			q.Set("scope", strings.Join(scopes, " "))
 		} else {
-			// Backwards compatibility or provider defaults might expect an empty scope parameter, 
+			// Backwards compatibility or provider defaults might expect an empty scope parameter,
 			// but we only set it if not explicitly skipping.
 			q.Set("scope", "")
 		}
 	}
-	
+
 	q.Set("state", state)
 	q.Set("code_challenge", codeChallenge)
 	q.Set("code_challenge_method", "S256")

--- a/nexus-broker/pkg/handlers/providers.go
+++ b/nexus-broker/pkg/handlers/providers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/httputil"
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/provider"
 
 	"github.com/go-chi/chi/v5"
@@ -35,8 +36,7 @@ func (h *ProvidersHandler) Get(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Provider not found", http.StatusNotFound)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(profile)
+	httputil.WriteJSON(w, http.StatusOK, profile)
 }
 
 // Update handles PUT /providers/{id} to update a provider profile
@@ -106,16 +106,13 @@ func (h *ProvidersHandler) Delete(w http.ResponseWriter, r *http.Request) {
 
 // Register handles POST /providers for registering a new provider profile
 func (h *ProvidersHandler) Register(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-
 	var request struct {
 		Profile json.RawMessage `json:"profile"`
 	}
 
 	// Decode request
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{
+		httputil.WriteJSON(w, http.StatusBadRequest, map[string]string{
 			"error":   "invalid_json",
 			"message": "Invalid JSON payload",
 		})
@@ -123,8 +120,7 @@ func (h *ProvidersHandler) Register(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if request.Profile == nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{
+		httputil.WriteJSON(w, http.StatusBadRequest, map[string]string{
 			"error":   "missing_profile",
 			"message": "Missing 'profile' key in JSON",
 		})
@@ -147,16 +143,14 @@ func (h *ProvidersHandler) Register(w http.ResponseWriter, r *http.Request) {
 			errorKey = "missing_" + strings.TrimSpace(field)
 		}
 
-		json.NewEncoder(w).Encode(map[string]string{
+		httputil.WriteJSON(w, http.StatusBadRequest, map[string]string{
 			"error":   errorKey,
 			"message": err.Error(),
 		})
 		return
 	}
 
-	// Success response
-	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	httputil.WriteJSON(w, http.StatusCreated, map[string]interface{}{
 		"id":      profile.ID,
 		"message": "Provider profile created successfully",
 	})
@@ -169,8 +163,7 @@ func (h *ProvidersHandler) List(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to list providers", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(rows)
+	httputil.WriteJSON(w, http.StatusOK, rows)
 }
 
 // GetByName handles GET /providers/by-name/{name}
@@ -190,8 +183,7 @@ func (h *ProvidersHandler) GetByName(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"id": profile.ID.String()})
+	httputil.WriteJSON(w, http.StatusOK, map[string]string{"id": profile.ID.String()})
 }
 
 // DeleteByName handles DELETE /providers/by-name/{name} to delete ALL providers with that name
@@ -224,6 +216,5 @@ func (h *ProvidersHandler) Metadata(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to retrieve metadata", http.StatusInternalServerError)
 		return
 	}
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(metadata)
+	httputil.WriteJSON(w, http.StatusOK, metadata)
 }

--- a/nexus-broker/pkg/httputil/response.go
+++ b/nexus-broker/pkg/httputil/response.go
@@ -1,0 +1,25 @@
+package httputil
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// WriteJSON marshals v to JSON and writes it to w with the given status code.
+// If marshalling fails, a 500 error response is sent instead (headers are not
+// yet committed, so this is safe). Write errors after headers are sent are
+// logged but cannot be recovered from — typically a client disconnect.
+func WriteJSON(w http.ResponseWriter, status int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		log.Printf("WriteJSON: marshal failed: %v", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if _, err := w.Write(data); err != nil {
+		log.Printf("WriteJSON: write failed (client likely disconnected): %v", err)
+	}
+}

--- a/nexus-broker/pkg/httputil/response_test.go
+++ b/nexus-broker/pkg/httputil/response_test.go
@@ -1,0 +1,79 @@
+package httputil
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWriteJSON_Success(t *testing.T) {
+	w := httptest.NewRecorder()
+	payload := map[string]string{"hello": "world"}
+
+	WriteJSON(w, http.StatusOK, payload)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected Content-Type application/json, got %q", ct)
+	}
+
+	var got map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if got["hello"] != "world" {
+		t.Fatalf("expected hello=world, got %q", got["hello"])
+	}
+}
+
+func TestWriteJSON_CustomStatus(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteJSON(w, http.StatusCreated, map[string]string{"id": "abc"})
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected status 201, got %d", w.Code)
+	}
+}
+
+func TestWriteJSON_MarshalFailure(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	// math.NaN is not representable in JSON — Marshal will fail.
+	WriteJSON(w, http.StatusOK, math.NaN())
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected status 500 on marshal failure, got %d", resp.StatusCode)
+	}
+}
+
+func TestWriteJSON_NilPayload(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteJSON(w, http.StatusOK, nil)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if body := w.Body.String(); body != "null" {
+		t.Fatalf("expected null body, got %q", body)
+	}
+}
+
+func TestWriteJSON_EmptySlice(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteJSON(w, http.StatusOK, []string{})
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+	if body := w.Body.String(); body != "[]" {
+		t.Fatalf("expected [] body, got %q", body)
+	}
+}

--- a/nexus-gateway/pkg/usecase/handler.go
+++ b/nexus-gateway/pkg/usecase/handler.go
@@ -37,11 +37,19 @@ type BrokerStatusError struct{ Status int }
 
 func (e *BrokerStatusError) Error() string { return fmt.Sprintf("broker status %d", e.Status) }
 
-// writeJSON encodes v as JSON with status
+// writeJSON marshals v to JSON and writes it to w with the given status code.
+// Marshalling happens before any bytes are written to w, so a 500 can still be
+// sent if encoding fails.
 func writeJSON(w http.ResponseWriter, status int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		logging.Error(context.Background(), "writeJSON.marshal_failed", map[string]any{"error": err.Error()})
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(v)
+	_, _ = w.Write(data)
 }
 
 // writeError writes a structured error body
@@ -399,8 +407,7 @@ func (h *Handler) CheckConnection(w http.ResponseWriter, r *http.Request) {
 	}
 	logging.Info(r.Context(), "check_connection.result", map[string]any{"connection_id": connectionID, "status": status})
 
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
+	writeJSON(w, http.StatusOK, map[string]string{"status": status})
 }
 
 func (h *Handler) GetToken(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Closes #32.

All `json.NewEncoder(w).Encode()` calls across both services have been replaced
with a **marshal-then-write** pattern that separates encoding from HTTP response
writing.

### The problem

`json.NewEncoder(w).Encode(v)` streams directly to the `http.ResponseWriter`.
The first byte written implicitly commits `200 OK` headers. If encoding fails
mid-stream (e.g. `NaN` float, malformed `json.RawMessage`), the client receives
a `200` with a partial or empty JSON body — and the server cannot retroactively
send a `500`.

### The fix

- **New `httputil.WriteJSON` helper** (broker): marshals to `[]byte` first via
  `json.Marshal`, then writes to `w` only on success. On marshal failure, a
  proper `500` is returned (headers not yet committed).
- **All 15 broker call sites** replaced across `callback.go`, `consent.go`, and
  `providers.go`.
- **Gateway `writeJSON`** updated from streaming `Encode` to the same
  marshal-first pattern. One remaining raw `Encode` call in `CheckConnection`
  also replaced.
- `Content-Type: application/json` is now set unconditionally by the helper.
- Write errors (client disconnect) are logged but not escalated — they're
  network-level, not server faults.

### Files changed

| File | Change |
|------|--------|
| `nexus-broker/pkg/httputil/response.go` | New `WriteJSON` helper |
| `nexus-broker/pkg/httputil/response_test.go` | 5 unit tests (success, custom status, marshal failure, nil, empty slice) |
| `nexus-broker/pkg/handlers/providers.go` | 8 `Encode` calls → `WriteJSON` |
| `nexus-broker/pkg/handlers/callback.go` | 5 `Encode` calls → `WriteJSON` |
| `nexus-broker/pkg/handlers/consent.go` | 2 `Encode` calls → `WriteJSON` |
| `nexus-gateway/pkg/usecase/handler.go` | `writeJSON` helper fixed + 1 remaining raw call replaced |

## Test plan

- [x] `WriteJSON` unit tests pass (success, marshal failure, nil, empty slice, custom status)
- [x] `nexus-broker` builds cleanly
- [x] `nexus-gateway` builds cleanly (both REST and gRPC)
- [x] `gofmt` passes on all modified files
- [x] Zero `json.NewEncoder(w).Encode` calls remain in production code
- [ ] Existing handler tests still pass (CI)
