### PR TITLE
refactor(bridge): replace goto Retry with for-loop in MaintainGRPCConnection

### DIFF
--- a/nexus-bridge/bridge.go
+++ b/nexus-bridge/bridge.go
@@ -109,9 +109,15 @@ func (b *Bridge) MaintainWebSocket(ctx context.Context, connectionID string, end
 	}
 }
 
-// MaintainGRPCConnection manages a persistent gRPC connection.
-// It handles authentication, dialing, and reconnection.
-// The 'run' function is called with the established ClientConn.
+// MaintainGRPCConnection manages a persistent gRPC connection with exponential
+// backoff and context-aware retry. The run callback receives each established
+// connection; its return value determines whether to retry, stop, or exit cleanly.
+//
+// Terminal conditions (no retry):
+//   - run returns nil (clean exit)
+//   - run returns ErrInteractionRequired (user must re-authenticate)
+//   - run returns a *PermanentError
+//   - context is cancelled
 func (b *Bridge) MaintainGRPCConnection(
 	ctx context.Context,
 	connectionID string,
@@ -119,76 +125,66 @@ func (b *Bridge) MaintainGRPCConnection(
 	run func(ctx context.Context, conn *grpc.ClientConn) error,
 	opts ...grpc.DialOption,
 ) error {
-	for {
-		// 1. Prepare Credentials
-		// We use our custom PerRPCCredentials implementation
-		creds := NewBridgeCredentials(b.oauthClient, connectionID, b.refreshBuffer, b.logger)
+	backoff := b.retryPolicy.MinBackoff
+	attempt := 0
 
-		// 2. Dial Options
-		// Default to TransportCredentials (TLS) usually, but allow insecure via opts if needed.
-		// However, PerRPCCredentials usually requires TLS.
-		// For simplicity/testing, we default to insecure if no transport creds provided,
-		// BUT BridgeCredentials.RequireTransportSecurity returns true, so gRPC will fail if insecure.
-		// We append our creds to the user provided options.
+	for {
+		if attempt > 0 {
+			wait := b.applyJitter(backoff)
+			b.logger.Info("Reconnecting gRPC", "target", target, "attempt", attempt, "after", wait)
+			select {
+			case <-ctx.Done():
+				b.logger.Info("Context cancelled during backoff; stopping gRPC bridge", "connectionID", connectionID)
+				return ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+		attempt++
+
+		creds := NewBridgeCredentials(b.oauthClient, connectionID, b.refreshBuffer, b.logger)
 		dialOpts := append(opts, grpc.WithPerRPCCredentials(creds))
 
-		// If user didn't provide transport credentials, we might need to add insecure for testing
-		// OR we assume user provides WithTransportCredentials.
-		// Let's assume user provides transport security options in 'opts'.
-		// But for a robust default, we check? No, we can't easily inspect DialOptions.
-		// We rely on the user to provide transport security (e.g. credentials.NewTLS) in 'opts'
-		// if they are connecting to a secure endpoint.
-
-		// 3. Dial
-		b.logger.Info("Dialing gRPC target", "target", target)
-		// Note: grpc.NewClient is the modern API, but Dial is still common. Using NewClient.
+		b.logger.Info("Dialing gRPC target", "target", target, "attempt", attempt)
 		conn, err := grpc.NewClient(target, dialOpts...)
 		if err != nil {
-			b.logger.Error(err, "Failed to dial gRPC target", "target", target)
-			// Dial errors are usually retryable (e.g. DNS)
-			goto Retry
+			b.logger.Error(err, "Failed to dial gRPC target", "target", target, "attempt", attempt)
+			backoff = b.growBackoff(backoff)
+			continue
 		}
 
 		b.metrics.IncConnections()
 		b.metrics.SetConnectionStatus(1)
 		b.logger.Info("gRPC connection established", "target", target)
 
-		// 4. Run User Logic
 		err = run(ctx, conn)
-		
-		// Cleanup
+
 		conn.Close()
 		b.metrics.SetConnectionStatus(0)
 		b.metrics.IncDisconnects()
 
-		// 5. Handle Error
-		if err != nil {
-			// Check if permanent
-			var permanentErr *PermanentError
-			if errors.As(err, &permanentErr) {
-				b.logger.Error(err, "Permanent error in gRPC run loop; stopping", "connectionID", connectionID)
-				return err
-			}
-			// Check if Context Done
-			if errors.Is(err, ctx.Err()) {
-				b.logger.Info("Context cancelled; shutting down gRPC bridge")
-				return err
-			}
-			
-			b.logger.Error(err, "gRPC run loop exited with error", "connectionID", connectionID)
-		} else {
+		if err == nil {
 			b.logger.Info("gRPC run loop exited cleanly", "connectionID", connectionID)
+			return nil
 		}
 
-	Retry:
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			backoff := b.calculateBackoff()
-			b.logger.Info("Reconnecting gRPC", "after", backoff)
-			time.Sleep(backoff)
+		if errors.Is(err, ErrInteractionRequired) {
+			b.logger.Error(err, "Interaction required; stopping gRPC retry", "connectionID", connectionID)
+			return err
 		}
+
+		var permanentErr *PermanentError
+		if errors.As(err, &permanentErr) {
+			b.logger.Error(err, "Permanent error in gRPC run loop; stopping", "connectionID", connectionID)
+			return err
+		}
+
+		if ctx.Err() != nil {
+			b.logger.Info("Context cancelled; shutting down gRPC bridge", "connectionID", connectionID)
+			return ctx.Err()
+		}
+
+		b.logger.Error(err, "gRPC run loop exited with error; will retry", "connectionID", connectionID, "attempt", attempt)
+		backoff = b.growBackoff(backoff)
 	}
 }
 
@@ -377,7 +373,25 @@ func (b *Bridge) manageConnection(ctx context.Context, connectionID string, endp
 	}
 }
 
-// NEW: Helper function for calculating backoff with jitter.
+// growBackoff doubles the current backoff, capping at MaxBackoff.
+func (b *Bridge) growBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > b.retryPolicy.MaxBackoff || next <= 0 {
+		return b.retryPolicy.MaxBackoff
+	}
+	return next
+}
+
+// applyJitter adds random jitter to a duration to prevent thundering herd
+// when multiple agents reconnect simultaneously after a gateway restart.
+func (b *Bridge) applyJitter(d time.Duration) time.Duration {
+	if b.retryPolicy.Jitter <= 0 {
+		return d
+	}
+	return d + time.Duration(rand.Int63n(int64(b.retryPolicy.Jitter)))
+}
+
+// calculateBackoff returns a flat backoff with jitter (used by MaintainWebSocket).
 func (b *Bridge) calculateBackoff() time.Duration {
 	backoff := b.retryPolicy.MinBackoff + time.Duration(rand.Int63n(int64(b.retryPolicy.Jitter)))
 	if backoff > b.retryPolicy.MaxBackoff {

--- a/nexus-bridge/bridge_test.go
+++ b/nexus-bridge/bridge_test.go
@@ -3,6 +3,7 @@ package bridge
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -12,13 +13,15 @@ import (
 
 	"github.com/Prescott-Data/nexus-framework/nexus-bridge/pkg/auth"
 	"github.com/gorilla/websocket"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // --- Mocks ---
 
 // mockOAuthClient is a mock implementation of the OAuthClient interface for testing.
 type mockOAuthClient struct {
-	getTokenFunc         func(ctx context.Context, connectionID string) (*Token, error)
+	getTokenFunc          func(ctx context.Context, connectionID string) (*Token, error)
 	refreshConnectionFunc func(ctx context.Context, connectionID string) (*Token, error)
 }
 
@@ -67,9 +70,9 @@ type mockMetrics struct {
 	connectionStatus atomic.Value
 }
 
-func (m *mockMetrics) IncConnections()           { atomic.AddInt32(&m.connections, 1) }
-func (m *mockMetrics) IncDisconnects()           { atomic.AddInt32(&m.disconnects, 1) }
-func (m *mockMetrics) IncTokenRefreshes()        { atomic.AddInt32(&m.tokenRefreshes, 1) }
+func (m *mockMetrics) IncConnections()                    { atomic.AddInt32(&m.connections, 1) }
+func (m *mockMetrics) IncDisconnects()                    { atomic.AddInt32(&m.disconnects, 1) }
+func (m *mockMetrics) IncTokenRefreshes()                 { atomic.AddInt32(&m.tokenRefreshes, 1) }
 func (m *mockMetrics) SetConnectionStatus(status float64) { m.connectionStatus.Store(status) }
 
 // testLogger is a mock implementation of the Logger interface for testing.
@@ -441,5 +444,238 @@ func TestBridge_TokenRefreshWithoutDisconnect(t *testing.T) {
 	}
 	if metrics.connectionStatus.Load() != 1.0 {
 		t.Errorf("Expected connection status to be 1, but got %v", metrics.connectionStatus.Load())
+	}
+}
+
+// --- gRPC retry loop tests ---
+
+func grpcRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MinBackoff: 10 * time.Millisecond,
+		MaxBackoff: 100 * time.Millisecond,
+		Jitter:     5 * time.Millisecond,
+	}
+}
+
+func TestGRPC_CleanExit(t *testing.T) {
+	t.Parallel()
+	authClient := &mockOAuthClient{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+			return &Token{
+				Strategy:    auth.AuthStrategy{Type: "oauth2"},
+				Credentials: auth.Credentials{"access_token": "tok"},
+				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+			}, nil
+		},
+	}
+
+	metrics := &mockMetrics{}
+	b := New(authClient, WithMetrics(metrics), WithRetryPolicy(grpcRetryPolicy()), WithLogger(&testLogger{t: t}))
+
+	run := func(ctx context.Context, conn *grpc.ClientConn) error {
+		return nil
+	}
+
+	err := b.MaintainGRPCConnection(context.Background(), "conn-1", "passthrough:///localhost:0",
+		run, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("expected nil error on clean exit, got: %v", err)
+	}
+	if atomic.LoadInt32(&metrics.connections) != 1 {
+		t.Errorf("expected 1 connection, got %d", metrics.connections)
+	}
+}
+
+func TestGRPC_PermanentError(t *testing.T) {
+	t.Parallel()
+	authClient := &mockOAuthClient{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+			return &Token{
+				Strategy:    auth.AuthStrategy{Type: "oauth2"},
+				Credentials: auth.Credentials{"access_token": "tok"},
+				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+			}, nil
+		},
+	}
+
+	metrics := &mockMetrics{}
+	b := New(authClient, WithMetrics(metrics), WithRetryPolicy(grpcRetryPolicy()), WithLogger(&testLogger{t: t}))
+
+	run := func(ctx context.Context, conn *grpc.ClientConn) error {
+		return NewPermanentError(fmt.Errorf("fatal"))
+	}
+
+	err := b.MaintainGRPCConnection(context.Background(), "conn-1", "passthrough:///localhost:0",
+		run, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	var permErr *PermanentError
+	if !errors.As(err, &permErr) {
+		t.Fatalf("expected PermanentError, got: %v", err)
+	}
+}
+
+func TestGRPC_InteractionRequired(t *testing.T) {
+	t.Parallel()
+	authClient := &mockOAuthClient{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+			return &Token{
+				Strategy:    auth.AuthStrategy{Type: "oauth2"},
+				Credentials: auth.Credentials{"access_token": "tok"},
+				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+			}, nil
+		},
+	}
+
+	metrics := &mockMetrics{}
+	b := New(authClient, WithMetrics(metrics), WithRetryPolicy(grpcRetryPolicy()), WithLogger(&testLogger{t: t}))
+
+	run := func(ctx context.Context, conn *grpc.ClientConn) error {
+		return ErrInteractionRequired
+	}
+
+	err := b.MaintainGRPCConnection(context.Background(), "conn-1", "passthrough:///localhost:0",
+		run, grpc.WithTransportCredentials(insecure.NewCredentials()))
+
+	if !errors.Is(err, ErrInteractionRequired) {
+		t.Fatalf("expected ErrInteractionRequired, got: %v", err)
+	}
+	if atomic.LoadInt32(&metrics.connections) != 1 {
+		t.Errorf("expected exactly 1 connection (no retry), got %d", metrics.connections)
+	}
+}
+
+func TestGRPC_RetryThenSucceed(t *testing.T) {
+	t.Parallel()
+	authClient := &mockOAuthClient{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+			return &Token{
+				Strategy:    auth.AuthStrategy{Type: "oauth2"},
+				Credentials: auth.Credentials{"access_token": "tok"},
+				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+			}, nil
+		},
+	}
+
+	var callCount int32
+	metrics := &mockMetrics{}
+	b := New(authClient, WithMetrics(metrics), WithRetryPolicy(grpcRetryPolicy()), WithLogger(&testLogger{t: t}))
+
+	run := func(ctx context.Context, conn *grpc.ClientConn) error {
+		n := atomic.AddInt32(&callCount, 1)
+		if n < 3 {
+			return fmt.Errorf("transient error #%d", n)
+		}
+		return nil
+	}
+
+	err := b.MaintainGRPCConnection(context.Background(), "conn-1", "passthrough:///localhost:0",
+		run, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("expected nil after retries, got: %v", err)
+	}
+	if atomic.LoadInt32(&callCount) != 3 {
+		t.Errorf("expected run called 3 times, got %d", callCount)
+	}
+	if atomic.LoadInt32(&metrics.connections) != 3 {
+		t.Errorf("expected 3 connections, got %d", metrics.connections)
+	}
+}
+
+func TestGRPC_ContextCancelledDuringBackoff(t *testing.T) {
+	t.Parallel()
+	authClient := &mockOAuthClient{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+			return &Token{
+				Strategy:    auth.AuthStrategy{Type: "oauth2"},
+				Credentials: auth.Credentials{"access_token": "tok"},
+				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+			}, nil
+		},
+	}
+
+	b := New(authClient, WithRetryPolicy(RetryPolicy{
+		MinBackoff: 10 * time.Second,
+		MaxBackoff: 10 * time.Second,
+		Jitter:     0,
+	}), WithLogger(&testLogger{t: t}))
+
+	var called int32
+	run := func(ctx context.Context, conn *grpc.ClientConn) error {
+		atomic.AddInt32(&called, 1)
+		return fmt.Errorf("transient")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errChan := make(chan error, 1)
+
+	go func() {
+		errChan <- b.MaintainGRPCConnection(ctx, "conn-1", "passthrough:///localhost:0",
+			run, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errChan:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("bridge did not exit promptly after context cancellation during backoff")
+	}
+
+	if atomic.LoadInt32(&called) != 1 {
+		t.Errorf("expected run called once before cancel, got %d", called)
+	}
+}
+
+func TestGRPC_BackoffGrowsExponentially(t *testing.T) {
+	t.Parallel()
+	authClient := &mockOAuthClient{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+			return &Token{
+				Strategy:    auth.AuthStrategy{Type: "oauth2"},
+				Credentials: auth.Credentials{"access_token": "tok"},
+				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
+			}, nil
+		},
+	}
+
+	b := New(authClient, WithRetryPolicy(RetryPolicy{
+		MinBackoff: 20 * time.Millisecond,
+		MaxBackoff: 500 * time.Millisecond,
+		Jitter:     0,
+	}), WithLogger(&testLogger{t: t}))
+
+	var timestamps []time.Time
+	var callCount int32
+
+	run := func(ctx context.Context, conn *grpc.ClientConn) error {
+		timestamps = append(timestamps, time.Now())
+		n := atomic.AddInt32(&callCount, 1)
+		if n >= 4 {
+			return nil
+		}
+		return fmt.Errorf("transient")
+	}
+
+	err := b.MaintainGRPCConnection(context.Background(), "conn-1", "passthrough:///localhost:0",
+		run, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(timestamps) < 4 {
+		t.Fatalf("expected at least 4 run calls, got %d", len(timestamps))
+	}
+
+	// Gaps between calls 2→3 and 3→4 should grow (backoff doubles each time).
+	for i := 2; i < len(timestamps); i++ {
+		prevGap := timestamps[i-1].Sub(timestamps[i-2])
+		thisGap := timestamps[i].Sub(timestamps[i-1])
+		if thisGap < prevGap {
+			t.Errorf("backoff did not grow: gap[%d]=%v < gap[%d]=%v", i, thisGap, i-1, prevGap)
+		}
 	}
 }

--- a/nexus-bridge/error.go
+++ b/nexus-bridge/error.go
@@ -1,19 +1,24 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gorilla/websocket"
 )
 
+// ErrInteractionRequired is returned when the gateway responds with 409
+// attention_required, indicating the user must re-authenticate. The bridge
+// must stop retrying — reconnecting will never succeed without user action.
+var ErrInteractionRequired = errors.New("interaction required: user must re-authenticate")
+
 // permanentCloseCodes contains WebSocket close codes that should not be retried.
 var permanentCloseCodes = map[int]bool{
-	websocket.CloseNormalClosure:      true,
-	websocket.ClosePolicyViolation:    true,
-	websocket.CloseInternalServerErr:  true,
+	websocket.CloseNormalClosure:           true,
+	websocket.ClosePolicyViolation:         true,
+	websocket.CloseInternalServerErr:       true,
 	websocket.CloseInvalidFramePayloadData: true, // e.g. invalid auth
 }
-
 
 // PermanentError represents an error that should not be retried.
 // When the bridge encounters this error, it will stop the reconnection loop.


### PR DESCRIPTION
## Summary

Closes #31.

Replaces the `goto Retry` anti-pattern in `MaintainGRPCConnection` with a
standard `for`/`continue` loop, unblocking the `attention_required` roadmap
feature and making the retry loop testable for the first time.

### What changed

- **`goto Retry` → `for` loop + `continue`**: All retry paths use `continue`
  to jump back to the top of the loop. No labels, no jump constraints on
  variable declarations.

- **Exponential backoff**: Backoff doubles on each failure (`MinBackoff` →
  `2×MinBackoff` → `4×MinBackoff` → ... → `MaxBackoff` cap). Previously the
  backoff was flat (`MinBackoff + rand(Jitter)` every time).

- **Context-aware wait**: Replaced `select { default: time.Sleep(backoff) }`
  with `select { case <-ctx.Done(): return; case <-time.After(wait): }`.
  Context cancellation during backoff is now immediate instead of blocked
  until the sleep completes.

- **`ErrInteractionRequired` sentinel**: New sentinel error in `error.go`.
  When `run` returns this error, the loop exits without retry — the user must
  re-authenticate. This directly unblocks Issue #3 (attention_required).

- **`applyJitter` helper**: Adds random jitter to backoff durations to prevent
  thundering herd when multiple agents reconnect simultaneously after a
  gateway restart.

- **Clean nil-return**: `run` returning `nil` now exits the loop cleanly
  (previously fell through to the retry block).

### Files changed

| File | Change |
|------|--------|
| `nexus-bridge/bridge.go` | Refactored `MaintainGRPCConnection`, added `growBackoff` and `applyJitter` |
| `nexus-bridge/error.go` | Added `ErrInteractionRequired` sentinel |
| `nexus-bridge/bridge_test.go` | Added 6 gRPC retry loop tests |

### New tests

| Test | Verifies |
|------|----------|
| `TestGRPC_CleanExit` | `run` returns nil → loop exits, no retry |
| `TestGRPC_PermanentError` | `run` returns `*PermanentError` → loop exits |
| `TestGRPC_InteractionRequired` | `run` returns `ErrInteractionRequired` → loop exits, exactly 1 connection |
| `TestGRPC_RetryThenSucceed` | `run` fails twice, succeeds third time → 3 connections, nil return |
| `TestGRPC_ContextCancelledDuringBackoff` | Context cancelled during 10s backoff → exits immediately |
| `TestGRPC_BackoffGrowsExponentially` | Gaps between retries grow: 40ms → 80ms → 160ms |

## Test plan

- [x] All 6 new gRPC retry tests pass
- [x] All existing WebSocket tests pass (except pre-existing `TestBridge_ContextCancellation` flake — same `time.Sleep` issue in the WebSocket path, out of scope)
- [x] Integration test `TestBridge_Integration_GRPC` passes
- [x] Zero `goto` statements remain in the bridge package
- [x] Package builds cleanly
- [x] `gofmt` passes on all modified files
