### PR TITLE
fix: Wave 1 — Standardize errors, consolidate config, formalize auth types (#47, #45, #42)

### DIFF
--- a/nexus-bridge/bridge.go
+++ b/nexus-bridge/bridge.go
@@ -14,21 +14,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-// MOCK for dromos-nexus-sdk
-type OAuthClient interface {
-	GetToken(ctx context.Context, connectionID string) (*Token, error)
-	RefreshConnection(ctx context.Context, connectionID string) (*Token, error)
-}
-
-type Token struct {
-	Strategy    auth.AuthStrategy
-	Credentials auth.Credentials
-	ExpiresAt   int64 // Unix timestamp
-}
-
 // Bridge manages persistent connections.
 type Bridge struct {
-	oauthClient      OAuthClient
+	oauthClient      auth.TokenProvider
 	logger           Logger
 	retryPolicy      RetryPolicy
 	metrics          Metrics
@@ -40,7 +28,7 @@ type Bridge struct {
 }
 
 // New creates a new Bridge with optional configurations.
-func New(oauthClient OAuthClient, opts ...Option) *Bridge {
+func New(oauthClient auth.TokenProvider, opts ...Option) *Bridge {
 	// Define default values
 	bridge := &Bridge{
 		oauthClient: oauthClient,
@@ -69,7 +57,7 @@ func New(oauthClient OAuthClient, opts ...Option) *Bridge {
 // NewStandard creates a new Bridge with production-ready defaults:
 // - Structured JSON logging (Slog) to Stdout
 // - Prometheus metrics registered to the default registry
-func NewStandard(oauthClient OAuthClient, agentLabels map[string]string, opts ...Option) *Bridge {
+func NewStandard(oauthClient auth.TokenProvider, agentLabels map[string]string, opts ...Option) *Bridge {
 	// Prepend telemetry options so user can still override them if needed (though unlikely)
 	defaultOpts := []Option{
 		WithLogger(telemetry.NewLogger()),
@@ -294,7 +282,7 @@ func (b *Bridge) manageConnection(ctx context.Context, connectionID string, endp
 	}()
 
 	// Step 5: Start the event loop for the active connection.
-	refreshResultChan := make(chan *Token, 1)
+	refreshResultChan := make(chan *auth.Token, 1)
 	refreshErrChan := make(chan error, 1)
 	refreshing := false
 	var timer *time.Timer

--- a/nexus-bridge/bridge_test.go
+++ b/nexus-bridge/bridge_test.go
@@ -19,17 +19,17 @@ import (
 
 // --- Mocks ---
 
-// mockOAuthClient is a mock implementation of the OAuthClient interface for testing.
-type mockOAuthClient struct {
-	getTokenFunc          func(ctx context.Context, connectionID string) (*Token, error)
-	refreshConnectionFunc func(ctx context.Context, connectionID string) (*Token, error)
+// mockTokenProvider is a mock implementation of auth.TokenProvider for testing.
+type mockTokenProvider struct {
+	getTokenFunc          func(ctx context.Context, connectionID string) (*auth.Token, error)
+	refreshConnectionFunc func(ctx context.Context, connectionID string) (*auth.Token, error)
 }
 
-func (m *mockOAuthClient) GetToken(ctx context.Context, connectionID string) (*Token, error) {
+func (m *mockTokenProvider) GetToken(ctx context.Context, connectionID string) (*auth.Token, error) {
 	return m.getTokenFunc(ctx, connectionID)
 }
 
-func (m *mockOAuthClient) RefreshConnection(ctx context.Context, connectionID string) (*Token, error) {
+func (m *mockTokenProvider) RefreshConnection(ctx context.Context, connectionID string) (*auth.Token, error) {
 	if m.refreshConnectionFunc != nil {
 		return m.refreshConnectionFunc(ctx, connectionID)
 	}
@@ -94,8 +94,8 @@ var upgrader = websocket.Upgrader{}
 
 func TestBridge_PermanentTokenError(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
 			return nil, errors.New("invalid credentials")
 		},
 	}
@@ -117,9 +117,9 @@ func TestBridge_PermanentTokenError(t *testing.T) {
 
 func TestBridge_PermanentCloseCode(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "test-token"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -156,9 +156,9 @@ func TestBridge_PermanentCloseCode(t *testing.T) {
 
 func TestBridge_ConnectionDropAndReconnect(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "test-token"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -211,9 +211,9 @@ func TestBridge_ConnectionDropAndReconnect(t *testing.T) {
 
 func TestBridge_ContextCancellation(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "test-token"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -254,9 +254,9 @@ func TestBridge_ContextCancellation(t *testing.T) {
 
 func TestBridge_HappyPath(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "test-token"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -294,9 +294,9 @@ func TestBridge_HappyPath(t *testing.T) {
 
 func TestBridge_MessageSizeLimit(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "test-token"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -341,7 +341,7 @@ func TestBridge_MessageSizeLimit(t *testing.T) {
 
 func TestBridge_Options(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{}
+	authClient := &mockTokenProvider{}
 	bridge := New(authClient,
 		WithMessageSizeLimit(1234),
 		WithWriteTimeout(5*time.Second),
@@ -366,19 +366,19 @@ func TestBridge_TokenRefreshWithoutDisconnect(t *testing.T) {
 	disconnectChan := make(chan error, 1)
 	refreshChan := make(chan struct{}) // Unbuffered channel
 
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
 			// Initial token expires soon.
-			return &Token{
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "initial-token"},
 				ExpiresAt:   time.Now().Add(2 * time.Second).Unix(),
 			}, nil
 		},
-		refreshConnectionFunc: func(ctx context.Context, connectionID string) (*Token, error) {
+		refreshConnectionFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
 			refreshChan <- struct{}{}
 			// Refreshed token has a long expiry.
-			return &Token{
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "refreshed-token"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -459,9 +459,9 @@ func grpcRetryPolicy() RetryPolicy {
 
 func TestGRPC_CleanExit(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "tok"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -488,9 +488,9 @@ func TestGRPC_CleanExit(t *testing.T) {
 
 func TestGRPC_PermanentError(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "tok"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -516,9 +516,9 @@ func TestGRPC_PermanentError(t *testing.T) {
 
 func TestGRPC_InteractionRequired(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "tok"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -546,9 +546,9 @@ func TestGRPC_InteractionRequired(t *testing.T) {
 
 func TestGRPC_RetryThenSucceed(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "tok"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -583,9 +583,9 @@ func TestGRPC_RetryThenSucceed(t *testing.T) {
 
 func TestGRPC_ContextCancelledDuringBackoff(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "tok"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -632,9 +632,9 @@ func TestGRPC_ContextCancelledDuringBackoff(t *testing.T) {
 
 func TestGRPC_BackoffGrowsExponentially(t *testing.T) {
 	t.Parallel()
-	authClient := &mockOAuthClient{
-		getTokenFunc: func(ctx context.Context, connectionID string) (*Token, error) {
-			return &Token{
+	authClient := &mockTokenProvider{
+		getTokenFunc: func(ctx context.Context, connectionID string) (*auth.Token, error) {
+			return &auth.Token{
 				Strategy:    auth.AuthStrategy{Type: "oauth2"},
 				Credentials: auth.Credentials{"access_token": "tok"},
 				ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),

--- a/nexus-bridge/grpc_credentials.go
+++ b/nexus-bridge/grpc_credentials.go
@@ -12,18 +12,17 @@ import (
 // BridgeCredentials implements credentials.PerRPCCredentials to automatically
 // inject authentication metadata into gRPC calls managed by the Bridge.
 type BridgeCredentials struct {
-	oauthClient   OAuthClient
+	oauthClient   auth.TokenProvider
 	connectionID  string
 	refreshBuffer time.Duration
 	logger        Logger
 
-	// Cache the current token to avoid fetching on every RPC
 	mu          sync.RWMutex
-	cachedToken *Token
+	cachedToken *auth.Token
 }
 
 // NewBridgeCredentials creates a new PerRPCCredentials handler.
-func NewBridgeCredentials(client OAuthClient, connectionID string, refreshBuffer time.Duration, logger Logger) *BridgeCredentials {
+func NewBridgeCredentials(client auth.TokenProvider, connectionID string, refreshBuffer time.Duration, logger Logger) *BridgeCredentials {
 	return &BridgeCredentials{
 		oauthClient:   client,
 		connectionID:  connectionID,
@@ -34,13 +33,11 @@ func NewBridgeCredentials(client OAuthClient, connectionID string, refreshBuffer
 
 // GetRequestMetadata is called by gRPC before sending a request.
 func (c *BridgeCredentials) GetRequestMetadata(ctx context.Context, uri ...string) (map[string]string, error) {
-	// 1. Get a valid token (cached or fresh)
 	token, err := c.getValidToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get valid credentials: %w", err)
 	}
 
-	// 2. Use the Auth Engine to generate the metadata map
 	md, err := auth.GetGRPCMetadata(token.Strategy, token.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate auth metadata: %w", err)
@@ -49,17 +46,15 @@ func (c *BridgeCredentials) GetRequestMetadata(ctx context.Context, uri ...strin
 	return md, nil
 }
 
-func (c *BridgeCredentials) getValidToken(ctx context.Context) (*Token, error) {
+func (c *BridgeCredentials) getValidToken(ctx context.Context) (*auth.Token, error) {
 	c.mu.RLock()
 	token := c.cachedToken
 	c.mu.RUnlock()
 
-	// If no token or expired, refresh
 	if token == nil || c.isExpired(token) {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 
-		// Double check locking
 		if c.cachedToken != nil && !c.isExpired(c.cachedToken) {
 			return c.cachedToken, nil
 		}
@@ -76,17 +71,14 @@ func (c *BridgeCredentials) getValidToken(ctx context.Context) (*Token, error) {
 	return token, nil
 }
 
-func (c *BridgeCredentials) isExpired(t *Token) bool {
+func (c *BridgeCredentials) isExpired(t *auth.Token) bool {
 	if t.ExpiresAt == 0 {
-		return false // No expiry
+		return false
 	}
-	// Check if we are within the buffer window
 	return time.Now().After(time.Unix(t.ExpiresAt, 0).Add(-c.refreshBuffer))
 }
 
 // RequireTransportSecurity indicates whether TLS is required.
 func (c *BridgeCredentials) RequireTransportSecurity() bool {
-	// Return false to allow use with insecure connections (e.g. for testing or on trusted networks).
-	// The user can still enforce TLS via grpc.WithTransportCredentials().
 	return false
 }

--- a/nexus-bridge/integration_test.go
+++ b/nexus-bridge/integration_test.go
@@ -15,9 +15,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Prescott-Data/nexus-framework/nexus-sdk"
 	"github.com/Prescott-Data/nexus-framework/nexus-bridge"
 	"github.com/Prescott-Data/nexus-framework/nexus-bridge/pkg/auth"
+	"github.com/Prescott-Data/nexus-framework/nexus-sdk"
 	"github.com/gorilla/websocket"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -28,12 +28,12 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// SDKAdapter adapts the oauthsdk.Client to the bridge.OAuthClient interface.
+// SDKAdapter adapts the oauthsdk.Client to the auth.TokenProvider interface.
 type SDKAdapter struct {
 	client *oauthsdk.Client
 }
 
-func (a *SDKAdapter) GetToken(ctx context.Context, connectionID string) (*bridge.Token, error) {
+func (a *SDKAdapter) GetToken(ctx context.Context, connectionID string) (*auth.Token, error) {
 	resp, err := a.client.GetToken(ctx, connectionID)
 	if err != nil {
 		return nil, err
@@ -41,7 +41,7 @@ func (a *SDKAdapter) GetToken(ctx context.Context, connectionID string) (*bridge
 	return a.convertToken(resp), nil
 }
 
-func (a *SDKAdapter) RefreshConnection(ctx context.Context, connectionID string) (*bridge.Token, error) {
+func (a *SDKAdapter) RefreshConnection(ctx context.Context, connectionID string) (*auth.Token, error) {
 	resp, err := a.client.RefreshConnection(ctx, connectionID)
 	if err != nil {
 		return nil, err
@@ -49,7 +49,7 @@ func (a *SDKAdapter) RefreshConnection(ctx context.Context, connectionID string)
 	return a.convertToken(resp), nil
 }
 
-func (a *SDKAdapter) convertToken(resp *oauthsdk.TokenResponse) *bridge.Token {
+func (a *SDKAdapter) convertToken(resp *oauthsdk.TokenResponse) *auth.Token {
 	var strategy auth.AuthStrategy
 	if resp.Strategy != nil {
 		strategy.Type, _ = resp.Strategy["type"].(string)
@@ -63,7 +63,7 @@ func (a *SDKAdapter) convertToken(resp *oauthsdk.TokenResponse) *bridge.Token {
 		creds = auth.Credentials(resp.Credentials)
 	}
 
-	return &bridge.Token{
+	return &auth.Token{
 		Strategy:    strategy,
 		Credentials: creds,
 		ExpiresAt:   time.Now().Add(1 * time.Hour).Unix(),
@@ -315,176 +315,145 @@ func TestBridge_Integration_GRPC(t *testing.T) {
 	broker := NewMockBroker()
 	defer broker.Close()
 
-		successChan := make(chan struct{})
+	successChan := make(chan struct{})
 
-		interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	interceptor := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 
-			md, ok := metadata.FromIncomingContext(ctx)
+		md, ok := metadata.FromIncomingContext(ctx)
 
-			if !ok {
+		if !ok {
 
-				return nil, status.Errorf(codes.Unauthenticated, "missing metadata")
-
-			}
-
-			t.Logf("gRPC Interceptor received metadata: %v", md)
-
-			if len(md.Get("authorization")) == 0 || md.Get("authorization")[0] != "Bearer grpc-secret-token" {
-
-				return nil, status.Errorf(codes.Unauthenticated, "invalid token")
-
-			}
-
-			// If validation is successful, signal it and call the handler
-
-			close(successChan)
-
-			return handler(ctx, req)
+			return nil, status.Errorf(codes.Unauthenticated, "missing metadata")
 
 		}
 
-	
+		t.Logf("gRPC Interceptor received metadata: %v", md)
 
-		provider, err := NewMockGRPCProvider(interceptor)
+		if len(md.Get("authorization")) == 0 || md.Get("authorization")[0] != "Bearer grpc-secret-token" {
+
+			return nil, status.Errorf(codes.Unauthenticated, "invalid token")
+
+		}
+
+		// If validation is successful, signal it and call the handler
+
+		close(successChan)
+
+		return handler(ctx, req)
+
+	}
+
+	provider, err := NewMockGRPCProvider(interceptor)
+
+	if err != nil {
+
+		t.Fatalf("Failed to create mock gRPC provider: %v", err)
+
+	}
+
+	defer provider.Close()
+
+	// 2. Configure Broker Response
+
+	broker.SetResponse("conn-grpc", map[string]interface{}{
+
+		"strategy": map[string]interface{}{
+
+			"type": "oauth2",
+		},
+
+		"credentials": map[string]interface{}{
+
+			"access_token": "grpc-secret-token",
+		},
+	})
+
+	// 3. Setup Bridge Client
+
+	sdkClient := oauthsdk.New(broker.URL())
+
+	adapter := &SDKAdapter{client: sdkClient}
+
+	b := bridge.New(adapter, bridge.WithLogger(&testLogger{t: t})) // Add logger to bridge
+
+	// 4. Run the Bridge
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+
+	defer cancel()
+
+	runFunc := func(ctx context.Context, conn *grpc.ClientConn) error {
+
+		client := grpc_health_v1.NewHealthClient(conn)
+
+		_, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: "test-service"})
 
 		if err != nil {
 
-			t.Fatalf("Failed to create mock gRPC provider: %v", err)
+			t.Logf("Health check failed: %v", err)
+
+			return err
 
 		}
 
-		defer provider.Close()
+		t.Logf("Health check successful")
 
-	
+		return nil
 
-		// 2. Configure Broker Response
+	}
 
-		broker.SetResponse("conn-grpc", map[string]interface{}{
+	// Run MaintainGRPCConnection in a goroutine
 
-			"strategy": map[string]interface{}{
+	go func() {
 
-				"type": "oauth2",
+		err := b.MaintainGRPCConnection(ctx, "conn-grpc", provider.Addr(), runFunc, grpc.WithTransportCredentials(insecure.NewCredentials()))
 
-			},
+		if err != nil {
 
-			"credentials": map[string]interface{}{
-
-				"access_token": "grpc-secret-token",
-
-			},
-
-		})
-
-	
-
-		// 3. Setup Bridge Client
-
-		sdkClient := oauthsdk.New(broker.URL())
-
-		adapter := &SDKAdapter{client: sdkClient}
-
-		b := bridge.New(adapter, bridge.WithLogger(&testLogger{t: t})) // Add logger to bridge
-
-	
-
-		// 4. Run the Bridge
-
-		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-
-		defer cancel()
-
-	
-
-		runFunc := func(ctx context.Context, conn *grpc.ClientConn) error {
-
-			client := grpc_health_v1.NewHealthClient(conn)
-
-			_, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: "test-service"})
-
-			if err != nil {
-
-				t.Logf("Health check failed: %v", err)
-
-				return err
-
-			}
-
-			t.Logf("Health check successful")
-
-			return nil
+			t.Logf("MaintainGRPCConnection exited with error: %v", err)
 
 		}
 
-	
+	}()
 
-		// Run MaintainGRPCConnection in a goroutine
+	// 5. Wait for validation signal
 
-		go func() {
+	select {
 
-			err := b.MaintainGRPCConnection(ctx, "conn-grpc", provider.Addr(), runFunc, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	case <-successChan:
 
-			if err != nil {
+		// Test passed!
 
-				t.Logf("MaintainGRPCConnection exited with error: %v", err)
+	case <-ctx.Done():
 
-			}
-
-		}()
-
-	
-
-		// 5. Wait for validation signal
-
-		select {
-
-		case <-successChan:
-
-			// Test passed!
-
-		case <-ctx.Done():
-
-			t.Fatal("Timeout waiting for successful gRPC call")
-
-		}
+		t.Fatal("Timeout waiting for successful gRPC call")
 
 	}
 
-	
+}
 
-	type noopHandler struct{}
+type noopHandler struct{}
 
-	
+func (h *noopHandler) OnConnect(send func(message []byte) error) {}
 
-	func (h *noopHandler) OnConnect(send func(message []byte) error) {}
+func (h *noopHandler) OnMessage(message []byte) {}
 
-	func (h *noopHandler) OnMessage(message []byte)                  {}
+func (h *noopHandler) OnDisconnect(err error) {}
 
-	func (h *noopHandler) OnDisconnect(err error)                    {}
+// testLogger is a mock implementation of the Logger interface for testing.
 
-	
+type testLogger struct {
+	t *testing.T
+}
 
-	// testLogger is a mock implementation of the Logger interface for testing.
+func (l *testLogger) Info(msg string, keysAndValues ...interface{}) {
 
-	type testLogger struct {
+	l.t.Logf("INFO: %s %v", msg, keysAndValues)
 
-		t *testing.T
+}
 
-	}
+func (l *testLogger) Error(err error, msg string, keysAndValues ...interface{}) {
 
-	
+	l.t.Logf("ERROR: %s %v err: %v", msg, keysAndValues, err)
 
-	func (l *testLogger) Info(msg string, keysAndValues ...interface{}) {
-
-		l.t.Logf("INFO: %s %v", msg, keysAndValues)
-
-	}
-
-	
-
-	func (l *testLogger) Error(err error, msg string, keysAndValues ...interface{}) {
-
-		l.t.Logf("ERROR: %s %v err: %v", msg, keysAndValues, err)
-
-	}
-
-	
+}

--- a/nexus-bridge/pkg/auth/token.go
+++ b/nexus-bridge/pkg/auth/token.go
@@ -1,0 +1,17 @@
+package auth
+
+import "context"
+
+// Token holds the resolved authentication details for a connection.
+type Token struct {
+	Strategy    AuthStrategy
+	Credentials Credentials
+	ExpiresAt   int64 // Unix timestamp
+}
+
+// TokenProvider retrieves and refreshes tokens for managed connections.
+// Implementations typically wrap the nexus-sdk HTTP client.
+type TokenProvider interface {
+	GetToken(ctx context.Context, connectionID string) (*Token, error)
+	RefreshConnection(ctx context.Context, connectionID string) (*Token, error)
+}

--- a/nexus-broker/cmd/nexus-broker/main.go
+++ b/nexus-broker/cmd/nexus-broker/main.go
@@ -3,9 +3,7 @@ package main
 import (
 	"context"
 	"log"
-	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/caching"
@@ -27,104 +25,71 @@ func main() {
 		os.Exit(0)
 	}
 
-	// Get configuration from environment
-	port := getEnv("PORT", "8080")
-	databaseURL := getEnv("DATABASE_URL", "postgres://user:password@localhost/oauth_broker?sslmode=disable")
-	databaseURL = enforceDBSSL(databaseURL)
-	baseURL := getEnv("BASE_URL", "http://localhost:8080")
-	encryptionKeyStr := getEnv("ENCRYPTION_KEY", "")
-	stateKeyStr := getEnv("STATE_KEY", "")
-	redisURL := getEnv("REDIS_URL", "redis://localhost:6379/0")
-
-	// Validate required environment variables
-	if databaseURL == "" {
-		log.Fatal("DATABASE_URL environment variable is required")
-	}
-	if baseURL == "" {
-		log.Fatal("BASE_URL environment variable is required")
-	}
-
-	// Validate required cryptographic keys — broker must not start without them.
-	// An ephemeral key would silently encrypt tokens that become unreadable on restart.
-	encryptionKey, err := config.ValidateKey("ENCRYPTION_KEY", encryptionKeyStr)
-	if err != nil {
-		log.Fatalf("Fatal configuration error: %v", err)
-	}
-	stateKey, err := config.ValidateKey("STATE_KEY", stateKeyStr)
+	cfg, err := config.Load()
 	if err != nil {
 		log.Fatalf("Fatal configuration error: %v", err)
 	}
 
-	log.Printf("ENCRYPTION_KEY fingerprint: %s", config.KeyFingerprint(encryptionKey))
-	log.Printf("STATE_KEY fingerprint: %s", config.KeyFingerprint(stateKey))
+	log.Printf("ENCRYPTION_KEY fingerprint: %s", config.KeyFingerprint(cfg.EncryptionKey))
+	log.Printf("STATE_KEY fingerprint: %s", config.KeyFingerprint(cfg.StateKey))
 
-	// Connect to database
-	db, err := sqlx.Connect("postgres", databaseURL)
+	db, err := sqlx.Connect("postgres", cfg.DatabaseURL)
 	if err != nil {
 		log.Fatal("Failed to connect to database:", err)
 	}
 	defer db.Close()
 
-	// Test database connection
 	if err := db.Ping(); err != nil {
 		log.Fatal("Failed to ping database:", err)
 	}
-
 	log.Println("Successfully connected to database")
 
-	// Connect to Redis
-	opts, err := redis.ParseURL(redisURL)
+	opts, err := redis.ParseURL(cfg.RedisURL)
 	if err != nil {
 		log.Fatal("Failed to parse REDIS_URL:", err)
 	}
-
 	redisClient := redis.NewClient(opts)
 	if err := redisClient.Ping(context.Background()).Err(); err != nil {
 		log.Fatal("Failed to ping Redis:", err)
 	}
 	log.Println("Successfully connected to Redis")
 
-	// Create caching client
 	cachingClient := caching.NewCachingClient(redisClient, 1*time.Hour)
 
-	// Create HTTP server
-	srv := server.NewServer(port)
-
-	// Create the REAL store
+	srv := server.NewServer(cfg.Port)
 	store := provider.NewStore(db)
 
-	// Setup handlers
-	redirectPath := os.Getenv("REDIRECT_PATH")
-	if redirectPath == "" {
-		redirectPath = "/auth/callback"
-	}
 	providersHandler := handlers.NewProvidersHandler(store)
 	consentHandler := handlers.NewConsentHandler(handlers.ConsentHandlerConfig{
-		DB:           db,
-		BaseURL:      baseURL,
-		RedirectPath: redirectPath,
-		StateKey:     stateKey,
-		HTTPClient:   cachingClient,
+		DB:                   db,
+		BaseURL:              cfg.BaseURL,
+		RedirectPath:         cfg.RedirectPath,
+		StateKey:             cfg.StateKey,
+		HTTPClient:           cachingClient,
+		EnforceReturnURL:     cfg.EnforceReturnURL,
+		AllowedReturnDomains: cfg.AllowedReturnDomains,
 	})
 	callbackHandler := handlers.NewCallbackHandler(handlers.CallbackHandlerConfig{
-		DB:            db,
-		BaseURL:       baseURL,
-		RedirectPath:  redirectPath,
-		EncryptionKey: encryptionKey,
-		StateKey:      stateKey,
-		HTTPClient:    cachingClient,
+		DB:                   db,
+		BaseURL:              cfg.BaseURL,
+		RedirectPath:         cfg.RedirectPath,
+		EncryptionKey:        cfg.EncryptionKey,
+		StateKey:             cfg.StateKey,
+		HTTPClient:           cachingClient,
+		EnforceReturnURL:     cfg.EnforceReturnURL,
+		AllowedReturnDomains: cfg.AllowedReturnDomains,
 	})
 
-	// Setup routes
 	router := srv.Router()
-	// Public endpoints
 	router.Get("/auth/callback", callbackHandler.Handle)
 	router.Method("GET", "/metrics", server.MetricsHandler())
-	// This is a new public, state-protected endpoint for the frontend
 	router.Get("/auth/capture-schema", callbackHandler.GetCaptureSchema)
 	router.Post("/auth/capture-credential", callbackHandler.SaveCredential)
-	// Protected endpoints: API key + allowlist
-	protected := router.With(server.ApiKeyMiddleware(), server.AllowlistMiddleware())
+
+	protected := router.With(
+		server.ApiKeyMiddleware(cfg.RequireAPIKey, cfg.APIKeys),
+		server.AllowlistMiddleware(cfg.RequireAllowlist, cfg.AllowedCIDRs),
+	)
 	protected.Route("/providers", func(r chi.Router) {
 		r.Post("/", providersHandler.Register)
 		r.Get("/", providersHandler.List)
@@ -140,68 +105,17 @@ func main() {
 	protected.Get("/connections/{connectionID}/token", callbackHandler.GetToken)
 	protected.Post("/connections/{connectionID}/refresh", callbackHandler.Refresh)
 
-	// Health check
 	router.Get("/health", server.HealthHandler)
 
-	// Start background orphan token cleanup (safety net for deleted connections)
 	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
 	defer cleanupCancel()
 	go handlers.StartOrphanTokenCleanup(cleanupCtx, db, 1*time.Hour)
 
-	log.Printf("Starting OAuth Broker server on port %s", port)
+	log.Printf("Starting OAuth Broker server on port %s", cfg.Port)
 	log.Printf("Version: %s", Version)
-	log.Printf("Base URL: %s", baseURL)
+	log.Printf("Base URL: %s", cfg.BaseURL)
 
 	if err := srv.Start(); err != nil {
 		log.Fatal("Server failed to start:", err)
 	}
-}
-
-// getEnv gets an environment variable with a fallback value
-func getEnv(key, fallback string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return fallback
-}
-
-// enforceDBSSL optionally enforces sslmode on the Postgres DSN based on env flags.
-// ENFORCE_DB_SSL=true enables enforcement. DB_SSLMODE (default "require") sets the mode.
-// DB_SSLROOTCERT can be provided to append sslrootcert=... for verify-ca/verify-full.
-func enforceDBSSL(dsn string) string {
-	if !strings.EqualFold(strings.TrimSpace(os.Getenv("ENFORCE_DB_SSL")), "true") {
-		return dsn
-	}
-	mode := strings.TrimSpace(os.Getenv("DB_SSLMODE"))
-	if mode == "" {
-		mode = "require"
-	}
-	root := strings.TrimSpace(os.Getenv("DB_SSLROOTCERT"))
-
-	u, err := url.Parse(dsn)
-	if err != nil || u.Scheme == "" || !strings.HasPrefix(dsn, "postgres") {
-		// Fallback: simple string append if DSN isn't a URL
-		if !strings.Contains(dsn, "sslmode=") {
-			if strings.Contains(dsn, "?") {
-				dsn += "&sslmode=" + mode
-			} else {
-				dsn += "?sslmode=" + mode
-			}
-		}
-		if root != "" && !strings.Contains(dsn, "sslrootcert=") {
-			if strings.Contains(dsn, "?") {
-				dsn += "&sslrootcert=" + url.QueryEscape(root)
-			} else {
-				dsn += "?sslrootcert=" + url.QueryEscape(root)
-			}
-		}
-		return dsn
-	}
-	q := u.Query()
-	q.Set("sslmode", mode)
-	if root != "" && q.Get("sslrootcert") == "" {
-		q.Set("sslrootcert", root)
-	}
-	u.RawQuery = q.Encode()
-	return u.String()
 }

--- a/nexus-broker/pkg/config/broker.go
+++ b/nexus-broker/pkg/config/broker.go
@@ -1,0 +1,155 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// BrokerConfig holds all configuration for the nexus-broker service.
+// Populated once at startup from environment variables, then passed to all
+// subsystems. No other package should read os.Getenv directly.
+type BrokerConfig struct {
+	Port        string
+	DatabaseURL string
+	BaseURL     string
+	RedisURL    string
+
+	EncryptionKey []byte
+	StateKey      []byte
+
+	RedirectPath string
+
+	// API key protection
+	RequireAPIKey bool
+	APIKeys       map[string]struct{}
+
+	// CIDR allowlist
+	RequireAllowlist bool
+	AllowedCIDRs     string
+
+	// Return URL enforcement
+	EnforceReturnURL     bool
+	AllowedReturnDomains []string
+
+	// DB SSL enforcement
+	EnforceDBSSL  bool
+	DBSSLMode     string
+	DBSSLRootCert string
+}
+
+// Load reads all configuration from environment variables, validates required
+// fields, and returns a fully populated BrokerConfig or a fatal error.
+func Load() (*BrokerConfig, error) {
+	cfg := &BrokerConfig{
+		Port:        envOr("PORT", "8080"),
+		DatabaseURL: envOr("DATABASE_URL", ""),
+		BaseURL:     envOr("BASE_URL", ""),
+		RedisURL:    envOr("REDIS_URL", "redis://localhost:6379/0"),
+
+		RedirectPath: envOr("REDIRECT_PATH", "/auth/callback"),
+
+		RequireAPIKey:    envBool("REQUIRE_API_KEY"),
+		RequireAllowlist: envBool("REQUIRE_ALLOWLIST"),
+		AllowedCIDRs:     envOr("ALLOWED_CIDRS", "127.0.0.1/32,::1/128"),
+
+		EnforceReturnURL: envBool("ENFORCE_RETURN_URL"),
+
+		EnforceDBSSL:  envBool("ENFORCE_DB_SSL"),
+		DBSSLMode:     envOr("DB_SSLMODE", "require"),
+		DBSSLRootCert: strings.TrimSpace(os.Getenv("DB_SSLROOTCERT")),
+	}
+
+	// Parse allowed return domains
+	if raw := strings.TrimSpace(os.Getenv("ALLOWED_RETURN_DOMAINS")); raw != "" {
+		for _, d := range strings.Split(raw, ",") {
+			d = strings.ToLower(strings.TrimSpace(d))
+			if d != "" {
+				cfg.AllowedReturnDomains = append(cfg.AllowedReturnDomains, d)
+			}
+		}
+	}
+
+	// Build API key allow-set
+	cfg.APIKeys = make(map[string]struct{})
+	if v := strings.TrimSpace(os.Getenv("API_KEYS")); v != "" {
+		for _, k := range strings.Split(v, ",") {
+			k = strings.TrimSpace(k)
+			if k != "" {
+				cfg.APIKeys[k] = struct{}{}
+			}
+		}
+	}
+	if v := strings.TrimSpace(os.Getenv("API_KEY")); v != "" {
+		cfg.APIKeys[v] = struct{}{}
+	}
+
+	// Required fields
+	if cfg.DatabaseURL == "" {
+		return nil, fmt.Errorf("DATABASE_URL environment variable is required")
+	}
+	if cfg.BaseURL == "" {
+		return nil, fmt.Errorf("BASE_URL environment variable is required")
+	}
+
+	// Cryptographic keys
+	var err error
+	cfg.EncryptionKey, err = ValidateKey("ENCRYPTION_KEY", os.Getenv("ENCRYPTION_KEY"))
+	if err != nil {
+		return nil, err
+	}
+	cfg.StateKey, err = ValidateKey("STATE_KEY", os.Getenv("STATE_KEY"))
+	if err != nil {
+		return nil, err
+	}
+
+	// Enforce DB SSL if configured
+	cfg.DatabaseURL = enforceDBSSL(cfg.DatabaseURL, cfg.EnforceDBSSL, cfg.DBSSLMode, cfg.DBSSLRootCert)
+
+	return cfg, nil
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func envBool(key string) bool {
+	return strings.EqualFold(strings.TrimSpace(os.Getenv(key)), "true")
+}
+
+func enforceDBSSL(dsn string, enforce bool, mode, rootCert string) string {
+	if !enforce {
+		return dsn
+	}
+
+	u, err := url.Parse(dsn)
+	if err != nil || u.Scheme == "" || !strings.HasPrefix(dsn, "postgres") {
+		if !strings.Contains(dsn, "sslmode=") {
+			sep := "?"
+			if strings.Contains(dsn, "?") {
+				sep = "&"
+			}
+			dsn += sep + "sslmode=" + mode
+		}
+		if rootCert != "" && !strings.Contains(dsn, "sslrootcert=") {
+			sep := "?"
+			if strings.Contains(dsn, "?") {
+				sep = "&"
+			}
+			dsn += sep + "sslrootcert=" + url.QueryEscape(rootCert)
+		}
+		return dsn
+	}
+
+	q := u.Query()
+	q.Set("sslmode", mode)
+	if rootCert != "" && q.Get("sslrootcert") == "" {
+		q.Set("sslrootcert", rootCert)
+	}
+	u.RawQuery = q.Encode()
+	return u.String()
+}

--- a/nexus-broker/pkg/config/broker_test.go
+++ b/nexus-broker/pkg/config/broker_test.go
@@ -1,0 +1,96 @@
+package config
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func testKey() string {
+	return base64.StdEncoding.EncodeToString(make([]byte, 32))
+}
+
+func TestLoad_MissingDatabaseURL(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+	t.Setenv("BASE_URL", "http://localhost")
+	t.Setenv("ENCRYPTION_KEY", testKey())
+	t.Setenv("STATE_KEY", testKey())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for missing DATABASE_URL")
+	}
+}
+
+func TestLoad_MissingBaseURL(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://localhost/db")
+	t.Setenv("BASE_URL", "")
+	t.Setenv("ENCRYPTION_KEY", testKey())
+	t.Setenv("STATE_KEY", testKey())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for missing BASE_URL")
+	}
+}
+
+func TestLoad_MissingEncryptionKey(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://localhost/db")
+	t.Setenv("BASE_URL", "http://localhost")
+	t.Setenv("ENCRYPTION_KEY", "")
+	t.Setenv("STATE_KEY", testKey())
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for missing ENCRYPTION_KEY")
+	}
+}
+
+func TestLoad_Success(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://localhost/db")
+	t.Setenv("BASE_URL", "http://localhost:8080")
+	t.Setenv("ENCRYPTION_KEY", testKey())
+	t.Setenv("STATE_KEY", testKey())
+	t.Setenv("REQUIRE_API_KEY", "true")
+	t.Setenv("API_KEYS", "key1,key2")
+	t.Setenv("ALLOWED_RETURN_DOMAINS", "example.com,*.foo.com")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Port != "8080" {
+		t.Errorf("expected default port 8080, got %s", cfg.Port)
+	}
+	if !cfg.RequireAPIKey {
+		t.Error("expected RequireAPIKey true")
+	}
+	if _, ok := cfg.APIKeys["key1"]; !ok {
+		t.Error("expected key1 in APIKeys")
+	}
+	if _, ok := cfg.APIKeys["key2"]; !ok {
+		t.Error("expected key2 in APIKeys")
+	}
+	if len(cfg.AllowedReturnDomains) != 2 {
+		t.Errorf("expected 2 allowed domains, got %d", len(cfg.AllowedReturnDomains))
+	}
+	if cfg.RedirectPath != "/auth/callback" {
+		t.Errorf("expected default redirect path, got %s", cfg.RedirectPath)
+	}
+}
+
+func TestLoad_DBSSLEnforcement(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://localhost/db")
+	t.Setenv("BASE_URL", "http://localhost")
+	t.Setenv("ENCRYPTION_KEY", testKey())
+	t.Setenv("STATE_KEY", testKey())
+	t.Setenv("ENFORCE_DB_SSL", "true")
+	t.Setenv("DB_SSLMODE", "verify-full")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DatabaseURL == "postgres://localhost/db" {
+		t.Error("expected DatabaseURL to have sslmode appended")
+	}
+}

--- a/nexus-broker/pkg/handlers/callback.go
+++ b/nexus-broker/pkg/handlers/callback.go
@@ -113,7 +113,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if code == "" || state == "" {
-		http.Error(w, "Missing code or state parameter", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "missing_params", "Missing code or state parameter")
 		return
 	}
 
@@ -121,14 +121,14 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	stateData, err := auth.VerifyState(h.stateKey, state)
 	if err != nil {
 		h.logAuditEvent(nil, "state_verification_failed", map[string]string{"error": err.Error()}, r)
-		http.Error(w, "Invalid state", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_state", "Invalid state")
 		return
 	}
 
 	// Get connection
 	connectionID, err := uuid.Parse(stateData.Nonce)
 	if err != nil {
-		http.Error(w, "Invalid connection ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_connection_id", "Invalid connection ID")
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		h.logAuditEvent(&connectionID, "connection_not_found", map[string]string{"error": err.Error()}, r)
-		http.Error(w, "Connection not found or expired", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "connection_not_found", "Connection not found or expired")
 		return
 	}
 
@@ -169,7 +169,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		h.logAuditEvent(&connectionID, "provider_not_found", map[string]string{"error": err.Error()}, r)
-		http.Error(w, "Provider not found", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "provider_not_found", "Provider not found")
 		return
 	}
 
@@ -201,7 +201,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 		h.logAuditEvent(&connectionID, "token_exchange_failed", map[string]string{"error": err.Error()}, r)
 		h.updateConnectionStatus(connectionID, "failed")
 		h.metricExchangeError.Inc()
-		http.Error(w, "Token exchange failed", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "token_exchange_failed", "Token exchange failed")
 		return
 	}
 	h.metricExchangeSuccess.Inc()
@@ -215,7 +215,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 			if _, err := oidcutil.VerifyIDToken(r.Context(), h.httpClient, raw, provider.ClientID.String, state); err != nil {
 				h.logAuditEvent(&connectionID, "id_token_verification_failed", map[string]string{"error": err.Error()}, r)
 				h.updateConnectionStatus(connectionID, "failed")
-				http.Error(w, "Invalid id_token", http.StatusUnauthorized)
+				httputil.WriteError(w, http.StatusUnauthorized, "invalid_id_token", "Invalid id_token")
 				return
 			}
 		}
@@ -225,7 +225,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	err = h.storeTokens(connectionID, tokens)
 	if err != nil {
 		h.logAuditEvent(&connectionID, "token_storage_failed", map[string]string{"error": err.Error()}, r)
-		http.Error(w, "Failed to store tokens", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "token_store_failed", "Failed to store tokens")
 		return
 	}
 
@@ -240,14 +240,14 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 
 	// Redirect to return URL with success
 	if !server.IsReturnURLAllowed(connection.ReturnURL) {
-		http.Error(w, "return_url not allowed", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "return_url_not_allowed", "return_url not allowed")
 		return
 	}
 
 	returnURL, err := url.Parse(connection.ReturnURL)
 	if err != nil {
 		h.logAuditEvent(&connectionID, "invalid_return_url", map[string]string{"error": err.Error(), "return_url": connection.ReturnURL}, r)
-		http.Error(w, "Invalid return_url", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "invalid_return_url", "Invalid return_url")
 		return
 	}
 	query := returnURL.Query()
@@ -266,13 +266,13 @@ func (h *CallbackHandler) GetCaptureSchema(w http.ResponseWriter, r *http.Reques
 	// Verify state
 	stateData, err := auth.VerifyState(h.stateKey, state)
 	if err != nil {
-		http.Error(w, "Invalid state", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_state", "Invalid state")
 		return
 	}
 
 	providerID, err := uuid.Parse(stateData.ProviderID)
 	if err != nil {
-		http.Error(w, "Invalid provider ID in state", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_provider_id", "Invalid provider ID in state")
 		return
 	}
 
@@ -283,21 +283,21 @@ func (h *CallbackHandler) GetCaptureSchema(w http.ResponseWriter, r *http.Reques
 
 	err = h.db.QueryRow("SELECT name, params FROM provider_profiles WHERE id = $1", providerID).Scan(&provider.Name, &provider.Params)
 	if err != nil {
-		http.Error(w, "Provider not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "provider_not_found", "Provider not found")
 		return
 	}
 
 	var params map[string]json.RawMessage
 	if provider.Params != nil {
 		if err := json.Unmarshal(*provider.Params, &params); err != nil {
-			http.Error(w, "Failed to parse provider params", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "params_parse_failed", "Failed to parse provider params")
 			return
 		}
 	}
 
 	schema, ok := params["credential_schema"]
 	if !ok {
-		http.Error(w, "Credential schema not found for this provider", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "schema_not_found", "Credential schema not found for this provider")
 		return
 	}
 
@@ -321,27 +321,27 @@ func (h *CallbackHandler) SaveCredential(w http.ResponseWriter, r *http.Request)
 		Credentials map[string]interface{} `json:"credentials"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
-		http.Error(w, "Invalid JSON body", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_json", "Invalid JSON body")
 		return
 	}
 
 	// Verify state
 	stateData, err := auth.VerifyState(h.stateKey, reqBody.State)
 	if err != nil {
-		http.Error(w, "Invalid state", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_state", "Invalid state")
 		return
 	}
 
 	connectionID, err := uuid.Parse(stateData.Nonce)
 	if err != nil {
-		http.Error(w, "Invalid connection ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_connection_id", "Invalid connection ID")
 		return
 	}
 
 	var returnURL string
 	err = h.db.QueryRow("SELECT return_url FROM connections WHERE id = $1", connectionID).Scan(&returnURL)
 	if err != nil {
-		http.Error(w, "Connection not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "connection_not_found", "Connection not found")
 		return
 	}
 
@@ -353,25 +353,25 @@ func (h *CallbackHandler) SaveCredential(w http.ResponseWriter, r *http.Request)
 		JOIN provider_profiles pp ON pp.id = c.provider_id
 		WHERE c.id = $1`, connectionID).Scan(&authType, &authHeader, &apiBaseURL, &userInfoEndpoint)
 	if err != nil {
-		http.Error(w, "Failed to load provider config", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "provider_config_failed", "Failed to load provider config")
 		return
 	}
 
 	if userInfoEndpoint != "" && apiBaseURL != "" {
 		if err := validateCredentials(authType, authHeader, apiBaseURL, userInfoEndpoint, reqBody.Credentials); err != nil {
-			http.Error(w, "Invalid credentials: "+err.Error(), http.StatusBadRequest)
+			httputil.WriteError(w, http.StatusBadRequest, "invalid_credentials", "Invalid credentials: "+err.Error())
 			return
 		}
 	}
 
 	err = h.storeTokens(connectionID, reqBody.Credentials)
 	if err != nil {
-		http.Error(w, "Failed to store credentials", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "credential_store_failed", "Failed to store credentials")
 		return
 	}
 
 	if err := h.updateConnectionStatus(connectionID, "active"); err != nil {
-		http.Error(w, "Failed to update connection status", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "status_update_failed", "Failed to update connection status")
 		return
 	}
 
@@ -444,7 +444,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 	// Extract connection ID from URL path
 	pathParts := strings.Split(r.URL.Path, "/")
 	if len(pathParts) < 3 {
-		http.Error(w, "Invalid path", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_path", "Invalid path")
 		return
 	}
 	connectionIDStr := pathParts[len(pathParts)-2] // /connections/{id}/token
@@ -452,7 +452,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 	connectionID, err := uuid.Parse(connectionIDStr)
 	if err != nil {
 		h.logAuditEvent(nil, "token_retrieval_failed", map[string]string{"error": "invalid connection ID", "id": connectionIDStr}, r)
-		http.Error(w, "Invalid connection ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_connection_id", "Invalid connection ID")
 		return
 	}
 
@@ -472,7 +472,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 
 	if err != nil {
 		h.logAuditEvent(&connectionID, "token_retrieval_failed", map[string]string{"error": "connection not found or db error", "id": connectionID.String()}, r)
-		http.Error(w, "Connection not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "connection_not_found", "Connection not found")
 		return
 	}
 
@@ -487,7 +487,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		http.Error(w, "Connection not active", http.StatusForbidden)
+		httputil.WriteError(w, http.StatusForbidden, "connection_not_active", "Connection not active")
 		return
 	}
 
@@ -500,7 +500,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 	err = h.db.QueryRow("SELECT encrypted_data, expires_at FROM tokens WHERE connection_id = $1", connectionID).Scan(&token.EncryptedData, &token.ExpiresAt)
 	if err != nil {
 		h.logAuditEvent(&connectionID, "token_retrieval_failed", map[string]string{"error": "token not found"}, r)
-		http.Error(w, "Token not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "token_not_found", "Token not found")
 		return
 	}
 
@@ -508,7 +508,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 	decryptedData, err := vault.Decrypt(h.encryptionKey, token.EncryptedData)
 	if err != nil {
 		h.logAuditEvent(&connectionID, "token_retrieval_failed", map[string]string{"error": "decryption failed"}, r)
-		http.Error(w, "Failed to decrypt token", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "decrypt_failed", "Failed to decrypt token")
 		return
 	}
 
@@ -516,7 +516,7 @@ func (h *CallbackHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 	var credentials map[string]interface{}
 	if err := json.Unmarshal(decryptedData, &credentials); err != nil {
 		h.logAuditEvent(&connectionID, "token_retrieval_failed", map[string]string{"error": "invalid token format"}, r)
-		http.Error(w, "Invalid token format", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "invalid_token_format", "Invalid token format")
 		return
 	}
 
@@ -686,13 +686,13 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	// Extract connection ID
 	parts := strings.Split(r.URL.Path, "/")
 	if len(parts) < 3 {
-		http.Error(w, "Invalid path", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_path", "Invalid path")
 		return
 	}
 	idStr := parts[len(parts)-2]
 	connectionID, err := uuid.Parse(idStr)
 	if err != nil {
-		http.Error(w, "Invalid connection ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_connection_id", "Invalid connection ID")
 		return
 	}
 
@@ -707,7 +707,7 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		WHERE c.id=$1 AND c.status='active'`, connectionID).Scan(&conn.ProviderID, &conn.AuthType)
 
 	if err != nil {
-		http.Error(w, "Connection not active or not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "connection_not_found", "Connection not active or not found")
 		return
 	}
 
@@ -715,7 +715,7 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 	switch conn.AuthType {
 	case "api_key", "basic_auth":
 		// Static tokens cannot be refreshed.
-		http.Error(w, "This connection uses a static token and cannot be refreshed", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "static_token", "This connection uses a static token and cannot be refreshed")
 		return // Stop execution here
 	case "oauth2", "":
 		// This is an OAuth2 provider, continue with the *existing* refresh logic
@@ -726,7 +726,7 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		}
 		err = h.db.QueryRow("SELECT token_url, client_id, client_secret FROM provider_profiles WHERE id=$1", conn.ProviderID).Scan(&provider.TokenURL, &provider.ClientID, &provider.ClientSecret)
 		if err != nil {
-			http.Error(w, "Provider not found", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "provider_not_found", "Provider not found")
 			return
 		}
 		var tokenRow struct {
@@ -734,22 +734,22 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		}
 		err = h.db.QueryRow("SELECT encrypted_data FROM tokens WHERE connection_id=$1", connectionID).Scan(&tokenRow.EncryptedData)
 		if err != nil {
-			http.Error(w, "Token not found", http.StatusNotFound)
+			httputil.WriteError(w, http.StatusNotFound, "token_not_found", "Token not found")
 			return
 		}
 		plaintext, err := vault.Decrypt(h.encryptionKey, tokenRow.EncryptedData)
 		if err != nil {
-			http.Error(w, "Decrypt failed", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "decrypt_failed", "Decrypt failed")
 			return
 		}
 		var current map[string]interface{}
 		if err := json.Unmarshal(plaintext, &current); err != nil {
-			http.Error(w, "Token parse failed", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "token_parse_failed", "Token parse failed")
 			return
 		}
 		refreshToken, _ := current["refresh_token"].(string)
 		if refreshToken == "" {
-			http.Error(w, "No refresh_token available", http.StatusBadRequest)
+			httputil.WriteError(w, http.StatusBadRequest, "no_refresh_token", "No refresh_token available")
 			return
 		}
 		// Refresh
@@ -768,17 +768,17 @@ func (h *CallbackHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 			}
 
 			// For 5xx or network errors, we don't change state, just fail the request (Agent will retry)
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			httputil.WriteError(w, http.StatusBadGateway, "upstream_error", err.Error())
 			return
 		}
 		// Store new tokens
 		if err := h.storeTokens(connectionID, newTokens); err != nil {
-			http.Error(w, "Store refreshed token failed", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "token_store_failed", "Store refreshed token failed")
 			return
 		}
 		httputil.WriteJSON(w, http.StatusOK, newTokens)
 	default:
-		http.Error(w, "Unsupported provider auth_type", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "unsupported_auth_type", "Unsupported provider auth_type")
 		return
 	}
 }
@@ -856,5 +856,5 @@ func (h *CallbackHandler) handleError(w http.ResponseWriter, r *http.Request, er
 		"description": description,
 	}, r)
 
-	http.Error(w, fmt.Sprintf("OAuth error: %s - %s", errorType, description), http.StatusBadRequest)
+	httputil.WriteError(w, http.StatusBadRequest, "oauth_error", fmt.Sprintf("OAuth error: %s - %s", errorType, description))
 }

--- a/nexus-broker/pkg/handlers/callback.go
+++ b/nexus-broker/pkg/handlers/callback.go
@@ -33,6 +33,8 @@ type CallbackHandler struct {
 	encryptionKey         []byte
 	stateKey              []byte
 	httpClient            *http.Client
+	enforceReturnURL      bool
+	allowedReturnDomains  []string
 	metricExchangeSuccess prometheus.Counter
 	metricExchangeError   prometheus.Counter
 	histogramExchangeDur  prometheus.Histogram
@@ -48,6 +50,9 @@ type CallbackHandlerConfig struct {
 	EncryptionKey []byte
 	StateKey      []byte
 	HTTPClient    *http.Client
+
+	EnforceReturnURL     bool
+	AllowedReturnDomains []string
 }
 
 // NewCallbackHandler creates a new callback handler
@@ -92,6 +97,8 @@ func NewCallbackHandler(cfg CallbackHandlerConfig) *CallbackHandler {
 		encryptionKey:         cfg.EncryptionKey,
 		stateKey:              cfg.StateKey,
 		httpClient:            cfg.HTTPClient,
+		enforceReturnURL:      cfg.EnforceReturnURL,
+		allowedReturnDomains:  cfg.AllowedReturnDomains,
 		metricExchangeSuccess: success,
 		metricExchangeError:   failure,
 		histogramExchangeDur:  hist,
@@ -239,7 +246,7 @@ func (h *CallbackHandler) Handle(w http.ResponseWriter, r *http.Request) {
 	h.logAuditEvent(&connectionID, "oauth_flow_completed", map[string]string{"provider_id": connection.ProviderID}, r)
 
 	// Redirect to return URL with success
-	if !server.IsReturnURLAllowed(connection.ReturnURL) {
+	if !server.IsReturnURLAllowed(connection.ReturnURL, h.enforceReturnURL, h.allowedReturnDomains) {
 		httputil.WriteError(w, http.StatusBadRequest, "return_url_not_allowed", "return_url not allowed")
 		return
 	}

--- a/nexus-broker/pkg/handlers/consent.go
+++ b/nexus-broker/pkg/handlers/consent.go
@@ -90,18 +90,18 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_json", "Invalid JSON")
 		return
 	}
 
 	// Validate required fields
 	if request.WorkspaceID == "" || request.ProviderID == "" || request.ReturnURL == "" {
-		http.Error(w, "Missing required fields", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "missing_fields", "Missing required fields")
 		return
 	}
 	// Validate return URL domain if enforced
 	if !server.IsReturnURLAllowed(request.ReturnURL) {
-		http.Error(w, "return_url not allowed", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "return_url_not_allowed", "return_url not allowed")
 		return
 	}
 
@@ -122,7 +122,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 	).Scan(&provider.ID, &provider.Name, &provider.AuthType, &provider.AuthURL, &provider.ClientID, pq.Array(&provider.Scopes), &provider.Params)
 	if err != nil {
 		log.Printf("/auth/consent-spec provider lookup error: %v", err)
-		http.Error(w, "Provider not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "provider_not_found", "Provider not found")
 		return
 	}
 
@@ -131,7 +131,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 		// Generate PKCE
 		codeVerifier, codeChallenge, err := auth.GeneratePKCE()
 		if err != nil {
-			http.Error(w, "Failed to generate PKCE", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "pkce_failed", "Failed to generate PKCE")
 			return
 		}
 
@@ -144,7 +144,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`,
 			connectionID, request.WorkspaceID, request.ProviderID, codeVerifier, pq.Array(request.Scopes), request.ReturnURL, expiresAt)
 		if err != nil {
-			http.Error(w, "Failed to create connection", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "connection_create_failed", "Failed to create connection")
 			return
 		}
 
@@ -158,7 +158,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 
 		signedState, err := auth.SignState(h.stateKey, stateData)
 		if err != nil {
-			http.Error(w, "Failed to sign state", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "state_sign_failed", "Failed to sign state")
 			return
 		}
 
@@ -182,7 +182,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 		// Build auth URL
 		authURL, err := h.buildAuthURL(useAuthURL, provider.ClientID.String, signedState, codeChallenge, request.Scopes, provider.Params)
 		if err != nil {
-			http.Error(w, "Failed to build auth URL", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "auth_url_failed", "Failed to build auth URL")
 			return
 		}
 
@@ -203,7 +203,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 			VALUES ($1, $2, $3, $4, $5, $6)`,
 			connectionID, request.WorkspaceID, request.ProviderID, pq.Array(request.Scopes), request.ReturnURL, expiresAt)
 		if err != nil {
-			http.Error(w, "Failed to create connection", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "connection_create_failed", "Failed to create connection")
 			return
 		}
 
@@ -216,7 +216,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 		}
 		signedState, err := auth.SignState(h.stateKey, stateData)
 		if err != nil {
-			http.Error(w, "Failed to sign state", http.StatusInternalServerError)
+			httputil.WriteError(w, http.StatusInternalServerError, "state_sign_failed", "Failed to sign state")
 			return
 		}
 
@@ -238,7 +238,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 
 		httputil.WriteJSON(w, http.StatusOK, response)
 	default:
-		http.Error(w, "Unsupported provider auth_type", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "unsupported_auth_type", "Unsupported provider auth_type")
 		return
 	}
 

--- a/nexus-broker/pkg/handlers/consent.go
+++ b/nexus-broker/pkg/handlers/consent.go
@@ -31,13 +31,15 @@ type ConsentSpec struct {
 
 // ConsentHandler handles OAuth consent flow
 type ConsentHandler struct {
-	db             *sqlx.DB
-	baseURL        string
-	redirectPath   string
-	stateKey       []byte
-	httpClient     *http.Client
-	consentsMetric prometheus.Counter
-	consentsOpenID prometheus.Counter
+	db                   *sqlx.DB
+	baseURL              string
+	redirectPath         string
+	stateKey             []byte
+	httpClient           *http.Client
+	enforceReturnURL     bool
+	allowedReturnDomains []string
+	consentsMetric       prometheus.Counter
+	consentsOpenID       prometheus.Counter
 }
 
 // ConsentHandlerConfig holds the dependencies for ConsentHandler
@@ -47,6 +49,9 @@ type ConsentHandlerConfig struct {
 	RedirectPath string
 	StateKey     []byte
 	HTTPClient   *http.Client
+
+	EnforceReturnURL     bool
+	AllowedReturnDomains []string
 }
 
 // NewConsentHandler creates a new consent handler
@@ -70,13 +75,15 @@ func NewConsentHandler(cfg ConsentHandlerConfig) *ConsentHandler {
 	}
 
 	return &ConsentHandler{
-		db:             cfg.DB,
-		baseURL:        cfg.BaseURL,
-		redirectPath:   cfg.RedirectPath,
-		stateKey:       cfg.StateKey,
-		httpClient:     cfg.HTTPClient,
-		consentsMetric: metric,
-		consentsOpenID: metricOpenID,
+		db:                   cfg.DB,
+		baseURL:              cfg.BaseURL,
+		redirectPath:         cfg.RedirectPath,
+		stateKey:             cfg.StateKey,
+		httpClient:           cfg.HTTPClient,
+		enforceReturnURL:     cfg.EnforceReturnURL,
+		allowedReturnDomains: cfg.AllowedReturnDomains,
+		consentsMetric:       metric,
+		consentsOpenID:       metricOpenID,
 	}
 }
 
@@ -100,7 +107,7 @@ func (h *ConsentHandler) GetSpec(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Validate return URL domain if enforced
-	if !server.IsReturnURLAllowed(request.ReturnURL) {
+	if !server.IsReturnURLAllowed(request.ReturnURL, h.enforceReturnURL, h.allowedReturnDomains) {
 		httputil.WriteError(w, http.StatusBadRequest, "return_url_not_allowed", "return_url not allowed")
 		return
 	}

--- a/nexus-broker/pkg/handlers/providers.go
+++ b/nexus-broker/pkg/handlers/providers.go
@@ -28,12 +28,12 @@ func (h *ProvidersHandler) Get(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
-		http.Error(w, "Invalid provider ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_provider_id", "Invalid provider ID")
 		return
 	}
 	profile, err := h.store.GetProfile(id)
 	if err != nil {
-		http.Error(w, "Provider not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "provider_not_found", "Provider not found")
 		return
 	}
 	httputil.WriteJSON(w, http.StatusOK, profile)
@@ -44,20 +44,20 @@ func (h *ProvidersHandler) Update(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
-		http.Error(w, "Invalid provider ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_provider_id", "Invalid provider ID")
 		return
 	}
 
 	var profile provider.Profile
 	if err := json.NewDecoder(r.Body).Decode(&profile); err != nil {
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_json", "Invalid JSON")
 		return
 	}
 
 	profile.ID = id
 
 	if err := h.store.UpdateProfile(&profile); err != nil {
-		http.Error(w, "Failed to update provider profile", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "update_failed", "Failed to update provider profile")
 		return
 	}
 
@@ -69,18 +69,18 @@ func (h *ProvidersHandler) Patch(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
-		http.Error(w, "Invalid provider ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_provider_id", "Invalid provider ID")
 		return
 	}
 
 	var updates map[string]interface{}
 	if err := json.NewDecoder(r.Body).Decode(&updates); err != nil {
-		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_json", "Invalid JSON")
 		return
 	}
 
 	if err := h.store.PatchProfile(id, updates); err != nil {
-		http.Error(w, "Failed to patch provider profile", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "patch_failed", "Failed to patch provider profile")
 		return
 	}
 
@@ -92,12 +92,12 @@ func (h *ProvidersHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	idStr := chi.URLParam(r, "id")
 	id, err := uuid.Parse(idStr)
 	if err != nil {
-		http.Error(w, "Invalid provider ID", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "invalid_provider_id", "Invalid provider ID")
 		return
 	}
 
 	if err := h.store.DeleteProfile(id); err != nil {
-		http.Error(w, "Failed to delete provider profile", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "delete_failed", "Failed to delete provider profile")
 		return
 	}
 
@@ -160,7 +160,7 @@ func (h *ProvidersHandler) Register(w http.ResponseWriter, r *http.Request) {
 func (h *ProvidersHandler) List(w http.ResponseWriter, r *http.Request) {
 	rows, err := h.store.ListProfiles()
 	if err != nil {
-		http.Error(w, "Failed to list providers", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "list_failed", "Failed to list providers")
 		return
 	}
 	httputil.WriteJSON(w, http.StatusOK, rows)
@@ -170,7 +170,7 @@ func (h *ProvidersHandler) List(w http.ResponseWriter, r *http.Request) {
 func (h *ProvidersHandler) GetByName(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	if name == "" {
-		http.Error(w, "missing name", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "missing_name", "missing name")
 		return
 	}
 
@@ -179,7 +179,7 @@ func (h *ProvidersHandler) GetByName(w http.ResponseWriter, r *http.Request) {
 
 	profile, err := h.store.GetProfileByName(name)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "provider_not_found", err.Error())
 		return
 	}
 
@@ -190,30 +190,29 @@ func (h *ProvidersHandler) GetByName(w http.ResponseWriter, r *http.Request) {
 func (h *ProvidersHandler) DeleteByName(w http.ResponseWriter, r *http.Request) {
 	name := chi.URLParam(r, "name")
 	if name == "" {
-		http.Error(w, "missing name", http.StatusBadRequest)
+		httputil.WriteError(w, http.StatusBadRequest, "missing_name", "missing name")
 		return
 	}
 
 	rowsAffected, err := h.store.DeleteProfileByName(name)
 	if err != nil {
-		http.Error(w, "Failed to delete provider profile", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "delete_failed", "Failed to delete provider profile")
 		return
 	}
 
 	if rowsAffected == 0 {
-		http.Error(w, "provider not found", http.StatusNotFound)
+		httputil.WriteError(w, http.StatusNotFound, "provider_not_found", "provider not found")
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(fmt.Sprintf("Deleted %d provider(s)", rowsAffected)))
+	httputil.WriteJSON(w, http.StatusOK, map[string]string{"message": fmt.Sprintf("Deleted %d provider(s)", rowsAffected)})
 }
 
 // Metadata handles GET /providers/metadata to retrieve grouped integration config
 func (h *ProvidersHandler) Metadata(w http.ResponseWriter, r *http.Request) {
 	metadata, err := h.store.GetMetadata()
 	if err != nil {
-		http.Error(w, "Failed to retrieve metadata", http.StatusInternalServerError)
+		httputil.WriteError(w, http.StatusInternalServerError, "metadata_failed", "Failed to retrieve metadata")
 		return
 	}
 	httputil.WriteJSON(w, http.StatusOK, metadata)

--- a/nexus-broker/pkg/httputil/response.go
+++ b/nexus-broker/pkg/httputil/response.go
@@ -6,6 +6,14 @@ import (
 	"net/http"
 )
 
+// APIError is the standard JSON error body returned by all broker endpoints.
+// Every failure path must use this shape so clients can parse errors uniformly.
+type APIError struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+	Details any    `json:"details,omitempty"`
+}
+
 // WriteJSON marshals v to JSON and writes it to w with the given status code.
 // If marshalling fails, a 500 error response is sent instead (headers are not
 // yet committed, so this is safe). Write errors after headers are sent are
@@ -13,7 +21,7 @@ import (
 func WriteJSON(w http.ResponseWriter, status int, v any) {
 	data, err := json.Marshal(v)
 	if err != nil {
-		http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		WriteError(w, http.StatusInternalServerError, "marshal_failed", "internal server error")
 		log.Printf("WriteJSON: marshal failed: %v", err)
 		return
 	}
@@ -22,4 +30,15 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 	if _, err := w.Write(data); err != nil {
 		log.Printf("WriteJSON: write failed (client likely disconnected): %v", err)
 	}
+}
+
+// WriteError writes a structured JSON error response. It replaces http.Error
+// across all handler code to ensure clients always receive application/json.
+func WriteError(w http.ResponseWriter, status int, code, message string) {
+	WriteJSON(w, status, APIError{Error: code, Message: message})
+}
+
+// WriteErrorWithDetails writes a structured JSON error response with extra detail.
+func WriteErrorWithDetails(w http.ResponseWriter, status int, code, message string, details any) {
+	WriteJSON(w, status, APIError{Error: code, Message: message, Details: details})
 }

--- a/nexus-broker/pkg/httputil/response_test.go
+++ b/nexus-broker/pkg/httputil/response_test.go
@@ -77,3 +77,56 @@ func TestWriteJSON_EmptySlice(t *testing.T) {
 		t.Fatalf("expected [] body, got %q", body)
 	}
 }
+
+func TestWriteError_StructuredJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteError(w, http.StatusBadRequest, "invalid_id", "Invalid provider ID")
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+
+	var got APIError
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if got.Error != "invalid_id" {
+		t.Errorf("expected error code invalid_id, got %q", got.Error)
+	}
+	if got.Message != "Invalid provider ID" {
+		t.Errorf("expected message 'Invalid provider ID', got %q", got.Message)
+	}
+	if got.Details != nil {
+		t.Errorf("expected nil details, got %v", got.Details)
+	}
+}
+
+func TestWriteError_500(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteError(w, http.StatusInternalServerError, "internal_error", "something broke")
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestWriteErrorWithDetails(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteErrorWithDetails(w, http.StatusUnprocessableEntity, "validation_failed", "bad input",
+		map[string]string{"field": "email"})
+
+	var got APIError
+	if err := json.NewDecoder(w.Result().Body).Decode(&got); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if got.Error != "validation_failed" {
+		t.Errorf("expected error code validation_failed, got %q", got.Error)
+	}
+	if got.Details == nil {
+		t.Fatal("expected non-nil details")
+	}
+}

--- a/nexus-broker/pkg/server/allowlist.go
+++ b/nexus-broker/pkg/server/allowlist.go
@@ -3,19 +3,13 @@ package server
 import (
 	"net"
 	"net/http"
-	"os"
 	"strings"
+
+	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/httputil"
 )
 
-// AllowlistMiddleware restricts access to specified CIDRs
-func AllowlistMiddleware() func(http.Handler) http.Handler {
-	require := strings.EqualFold(strings.TrimSpace(os.Getenv("REQUIRE_ALLOWLIST")), "true")
-	allowedCIDRs := os.Getenv("ALLOWED_CIDRS")
-	if allowedCIDRs == "" {
-		// Default to localhost for development
-		allowedCIDRs = "127.0.0.1/32,::1/128"
-	}
-
+// AllowlistMiddleware restricts access to the specified CIDRs when require is true.
+func AllowlistMiddleware(require bool, allowedCIDRs string) func(http.Handler) http.Handler {
 	var nets []*net.IPNet
 	for _, cidr := range strings.Split(allowedCIDRs, ",") {
 		cidr = strings.TrimSpace(cidr)
@@ -44,7 +38,7 @@ func AllowlistMiddleware() func(http.Handler) http.Handler {
 			}
 
 			if !allowed {
-				http.Error(w, "Access denied", http.StatusForbidden)
+				httputil.WriteError(w, http.StatusForbidden, "access_denied", "Access denied")
 				return
 			}
 
@@ -53,11 +47,8 @@ func AllowlistMiddleware() func(http.Handler) http.Handler {
 	}
 }
 
-// getClientIP extracts the real client IP
 func getClientIP(r *http.Request) net.IP {
-	// Check X-Forwarded-For header (if behind a trusted proxy)
 	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first IP in the chain
 		ips := strings.Split(xff, ",")
 		if len(ips) > 0 {
 			ip := net.ParseIP(strings.TrimSpace(ips[0]))
@@ -67,10 +58,9 @@ func getClientIP(r *http.Request) net.IP {
 		}
 	}
 
-	// Fall back to RemoteAddr
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
-		return net.ParseIP("127.0.0.1") // fallback
+		return net.ParseIP("127.0.0.1")
 	}
 	return net.ParseIP(host)
 }

--- a/nexus-broker/pkg/server/allowlist_test.go
+++ b/nexus-broker/pkg/server/allowlist_test.go
@@ -13,7 +13,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		require        string
+		require        bool
 		cidrs          string
 		remoteAddr     string
 		forwardedFor   string
@@ -21,7 +21,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 	}{
 		{
 			name:           "Not required",
-			require:        "false",
+			require:        false,
 			cidrs:          "",
 			remoteAddr:     "1.1.1.1:12345",
 			forwardedFor:   "",
@@ -29,7 +29,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 		},
 		{
 			name:           "Allowed from RemoteAddr",
-			require:        "true",
+			require:        true,
 			cidrs:          "192.168.1.0/24",
 			remoteAddr:     "192.168.1.10:12345",
 			forwardedFor:   "",
@@ -37,7 +37,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 		},
 		{
 			name:           "Disallowed from RemoteAddr",
-			require:        "true",
+			require:        true,
 			cidrs:          "192.168.1.0/24",
 			remoteAddr:     "10.0.0.5:12345",
 			forwardedFor:   "",
@@ -45,7 +45,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 		},
 		{
 			name:           "Allowed from X-Forwarded-For",
-			require:        "true",
+			require:        true,
 			cidrs:          "10.0.0.0/16",
 			remoteAddr:     "1.1.1.1:12345",
 			forwardedFor:   "10.0.5.1",
@@ -53,7 +53,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 		},
 		{
 			name:           "Disallowed from X-Forwarded-For",
-			require:        "true",
+			require:        true,
 			cidrs:          "10.0.0.0/16",
 			remoteAddr:     "1.1.1.1:12345",
 			forwardedFor:   "172.16.0.1",
@@ -63,9 +63,6 @@ func TestAllowlistMiddleware(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("REQUIRE_ALLOWLIST", tc.require)
-			t.Setenv("ALLOWED_CIDRS", tc.cidrs)
-
 			req := httptest.NewRequest("GET", "/", nil)
 			req.RemoteAddr = tc.remoteAddr
 			if tc.forwardedFor != "" {
@@ -73,7 +70,7 @@ func TestAllowlistMiddleware(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := AllowlistMiddleware()(nextHandler)
+			handler := AllowlistMiddleware(tc.require, tc.cidrs)(nextHandler)
 			handler.ServeHTTP(rr, req)
 
 			if status := rr.Code; status != tc.expectedStatus {

--- a/nexus-broker/pkg/server/apikey.go
+++ b/nexus-broker/pkg/server/apikey.go
@@ -2,41 +2,26 @@ package server
 
 import (
 	"net/http"
-	"os"
 	"strings"
+
+	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/httputil"
 )
 
-// ApiKeyMiddleware enforces X-API-Key header when REQUIRE_API_KEY=true.
-// Keys can be provided via API_KEYS (comma-separated) or API_KEY (single).
-func ApiKeyMiddleware() func(http.Handler) http.Handler {
-	require := strings.EqualFold(strings.TrimSpace(os.Getenv("REQUIRE_API_KEY")), "true")
-	// Build an allow set
-	allow := make(map[string]struct{})
-	if v := strings.TrimSpace(os.Getenv("API_KEYS")); v != "" {
-		for _, k := range strings.Split(v, ",") {
-			k = strings.TrimSpace(k)
-			if k != "" {
-				allow[k] = struct{}{}
-			}
-		}
-	}
-	if v := strings.TrimSpace(os.Getenv("API_KEY")); v != "" {
-		allow[v] = struct{}{}
-	}
-
+// ApiKeyMiddleware enforces X-API-Key header when requireKey is true.
+func ApiKeyMiddleware(requireKey bool, allowedKeys map[string]struct{}) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if !require {
+			if !requireKey {
 				next.ServeHTTP(w, r)
 				return
 			}
 			key := strings.TrimSpace(r.Header.Get("X-API-Key"))
 			if key == "" {
-				http.Error(w, "missing api key", http.StatusUnauthorized)
+				httputil.WriteError(w, http.StatusUnauthorized, "missing_api_key", "missing api key")
 				return
 			}
-			if _, ok := allow[key]; !ok {
-				http.Error(w, "invalid api key", http.StatusForbidden)
+			if _, ok := allowedKeys[key]; !ok {
+				httputil.WriteError(w, http.StatusForbidden, "invalid_api_key", "invalid api key")
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/nexus-broker/pkg/server/apikey_test.go
+++ b/nexus-broker/pkg/server/apikey_test.go
@@ -13,35 +13,35 @@ func TestApiKeyMiddleware(t *testing.T) {
 
 	testCases := []struct {
 		name           string
-		require        string
+		require        bool
 		apiKey         string
 		headerKey      string
 		expectedStatus int
 	}{
 		{
 			name:           "Not required",
-			require:        "false",
+			require:        false,
 			apiKey:         "",
 			headerKey:      "",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Valid key",
-			require:        "true",
+			require:        true,
 			apiKey:         "valid-key",
 			headerKey:      "valid-key",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Missing key",
-			require:        "true",
+			require:        true,
 			apiKey:         "valid-key",
 			headerKey:      "",
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
 			name:           "Invalid key",
-			require:        "true",
+			require:        true,
 			apiKey:         "valid-key",
 			headerKey:      "invalid-key",
 			expectedStatus: http.StatusForbidden,
@@ -50,8 +50,10 @@ func TestApiKeyMiddleware(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("REQUIRE_API_KEY", tc.require)
-			t.Setenv("API_KEY", tc.apiKey)
+			keys := make(map[string]struct{})
+			if tc.apiKey != "" {
+				keys[tc.apiKey] = struct{}{}
+			}
 
 			req := httptest.NewRequest("GET", "/", nil)
 			if tc.headerKey != "" {
@@ -59,7 +61,7 @@ func TestApiKeyMiddleware(t *testing.T) {
 			}
 
 			rr := httptest.NewRecorder()
-			handler := ApiKeyMiddleware()(nextHandler)
+			handler := ApiKeyMiddleware(tc.require, keys)(nextHandler)
 			handler.ServeHTTP(rr, req)
 
 			if status := rr.Code; status != tc.expectedStatus {

--- a/nexus-broker/pkg/server/returnurl.go
+++ b/nexus-broker/pkg/server/returnurl.go
@@ -3,13 +3,12 @@ package server
 import (
 	"net"
 	"net/url"
-	"os"
 	"strings"
 )
 
-// IsReturnURLAllowed validates the return URL host against ALLOWED_RETURN_DOMAINS when ENFORCE_RETURN_URL=true.
-func IsReturnURLAllowed(raw string) bool {
-	enforce := strings.EqualFold(strings.TrimSpace(os.Getenv("ENFORCE_RETURN_URL")), "true")
+// IsReturnURLAllowed validates the return URL host against the allowed domains
+// when enforce is true. If enforce is false, all URLs are allowed.
+func IsReturnURLAllowed(raw string, enforce bool, allowedDomains []string) bool {
 	if !enforce {
 		return true
 	}
@@ -21,17 +20,11 @@ func IsReturnURLAllowed(raw string) bool {
 	if h, _, err := net.SplitHostPort(host); err == nil && h != "" {
 		host = h
 	}
-	allowed := strings.Split(strings.TrimSpace(os.Getenv("ALLOWED_RETURN_DOMAINS")), ",")
 	host = strings.ToLower(strings.TrimSpace(host))
-	for _, a := range allowed {
-		a = strings.ToLower(strings.TrimSpace(a))
-		if a == "" {
-			continue
-		}
+	for _, a := range allowedDomains {
 		if a == host {
 			return true
 		}
-		// Optional simple wildcard: *.example.com
 		if strings.HasPrefix(a, "*.") {
 			suf := strings.TrimPrefix(a, "*.")
 			if strings.HasSuffix(host, "."+suf) {

--- a/nexus-broker/pkg/server/returnurl_test.go
+++ b/nexus-broker/pkg/server/returnurl_test.go
@@ -1,55 +1,56 @@
 package server
 
 import (
+	"strings"
 	"testing"
 )
 
 func TestIsReturnURLAllowed(t *testing.T) {
 	testCases := []struct {
-		name          string
-		enforce       string
-		allowed       string
-		url           string
-		expected      bool
+		name     string
+		enforce  bool
+		allowed  string
+		url      string
+		expected bool
 	}{
 		{
 			name:     "Enforcement disabled",
-			enforce:  "false",
+			enforce:  false,
 			allowed:  "",
 			url:      "https://any.com",
 			expected: true,
 		},
 		{
 			name:     "Simple match",
-			enforce:  "true",
+			enforce:  true,
 			allowed:  "example.com",
 			url:      "https://example.com/foo",
 			expected: true,
 		},
 		{
 			name:     "Simple mismatch",
-			enforce:  "true",
+			enforce:  true,
 			allowed:  "example.com",
 			url:      "https://bad.com/foo",
 			expected: false,
 		},
 		{
 			name:     "URL with port",
-			enforce:  "true",
+			enforce:  true,
 			allowed:  "localhost",
 			url:      "http://localhost:3000",
 			expected: true,
 		},
 		{
 			name:     "Wildcard match",
-			enforce:  "true",
+			enforce:  true,
 			allowed:  "*.example.com",
 			url:      "https://app.example.com",
 			expected: true,
 		},
 		{
 			name:     "Invalid URL",
-			enforce:  "true",
+			enforce:  true,
 			allowed:  "example.com",
 			url:      "://invalid-url",
 			expected: false,
@@ -58,10 +59,14 @@ func TestIsReturnURLAllowed(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Setenv("ENFORCE_RETURN_URL", tc.enforce)
-			t.Setenv("ALLOWED_RETURN_DOMAINS", tc.allowed)
+			var domains []string
+			if tc.allowed != "" {
+				for _, d := range strings.Split(tc.allowed, ",") {
+					domains = append(domains, strings.ToLower(strings.TrimSpace(d)))
+				}
+			}
 
-			if got := IsReturnURLAllowed(tc.url); got != tc.expected {
+			if got := IsReturnURLAllowed(tc.url, tc.enforce, domains); got != tc.expected {
 				t.Errorf("IsReturnURLAllowed() = %v, want %v", got, tc.expected)
 			}
 		})


### PR DESCRIPTION
## Summary

Wave 1 foundational improvements covering three related issues:

- **#47 — Standardize Error Handling**: Replace all 71 `http.Error()` calls across broker handlers with `httputil.WriteError()`, ensuring every failure returns consistent JSON `{error, message, details?}` instead of plain text. Add `APIError` struct, `WriteError`, and `WriteErrorWithDetails` helpers.
- **#45 — Consolidate Configuration**: Create `config.Load()` that reads all env vars once at startup and returns a validated `BrokerConfig` struct. Middleware factories (`ApiKeyMiddleware`, `AllowlistMiddleware`, `IsReturnURLAllowed`) now accept explicit parameters, eliminating scattered `os.Getenv` calls from 4 files.
- **#42 — Formalize Auth Types**: Move `Token` struct and `OAuthClient` interface from `bridge.go` into `pkg/auth` as `auth.Token` and `auth.TokenProvider`. Removes the "MOCK" comment and establishes a proper, importable contract.

## Test plan

- [x] All `nexus-broker/pkg/...` tests pass (httputil, config, handlers, server, auth, caching, provider)
- [x] All `nexus-bridge/...` tests pass (15 unit + integration tests including gRPC and WebSocket)
- [x] All `nexus-gateway/...` tests pass
- [x] All `nexus-sdk/...` tests pass
- [x] Broker builds successfully (`go build ./cmd/nexus-broker`)
- [x] Bridge builds successfully (`go build ./...`)
