### PR TITLE
Feat/doc site update

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,6 +10,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME_BROKER: Prescott-Data/nexus-broker
   IMAGE_NAME_GATEWAY: Prescott-Data/nexus-gateway
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-push:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/doc-site-update
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
@@ -39,11 +40,15 @@ jobs:
         run: mkdocs build --clean
 
       - name: Upload Pages artifact
+        # Only upload artifact when on main (Pages deploy only runs from main)
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site/
 
   deploy:
+    # Only deploy to GitHub Pages from main
+    if: github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ permissions:
   pages: write        # deploy to GitHub Pages
   id-token: write     # OIDC token for Pages deployment
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 concurrency:
   group: pages
   cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -773,6 +773,38 @@ body,
 
 
 /* ============================================================
+   HIDE MATERIAL'S BUILT-IN GLOBE / EXTERNAL-LINK ICON
+   Material injects an inline <svg> globe on every nav link
+   pointing to an external URL — sidebar items AND TOC headings.
+   We already have purpose-built ::before icons for the three
+   Home links (Website, Community, Blog), so suppress the
+   auto-injected globe everywhere else.
+   ============================================================ */
+
+/* Left sidebar — primary nav tree */
+.md-nav--primary .md-nav__link > svg.md-icon,
+.md-nav--primary .md-nav__link > .md-ellipsis > svg.md-icon {
+  display: none !important;
+}
+
+/* Right sidebar — table of contents */
+.md-nav--secondary .md-nav__link > svg.md-icon,
+.md-nav--secondary .md-nav__link > .md-ellipsis > svg.md-icon {
+  display: none !important;
+}
+
+/* Mobile drawer */
+.md-nav--integrated .md-nav__link > svg.md-icon {
+  display: none !important;
+}
+
+/* Broad catch-all for any remaining injected SVG globe in sidebars */
+.md-sidebar .md-nav__link > svg[viewBox] {
+  display: none !important;
+}
+
+
+/* ============================================================
    LEFT SIDEBAR — premium redesign
    ============================================================ */
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Nexus
 site_description: Provider-agnostic credential brokering for autonomous agents. Built by Prescott Data.
-site_url: https://prescott-data.github.io/nexus-framework/
+site_url: https://nexus.developers.prescottdata.io/
 repo_url: https://github.com/Prescott-Data/nexus-framework
 repo_name: Prescott-Data/nexus-framework
 edit_uri: edit/main/docs/


### PR DESCRIPTION
# Pull Request

## Description

Fixes the Nexus documentation site (`nexus.developers.prescottdata.io`) build failure and a visual regression where the globe icon was appearing on every sidebar and table of contents item. Also modernises the CI workflows to opt into Node.js 24 ahead of the GitHub Actions forced cutover on June 2, 2026.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Changes Made

| File | Summary |
|---|---|
| `mkdocs.yml` | Updated `site_url` from the old GitHub Pages URL to the actual deployed domain (`nexus.developers.prescottdata.io`). This was the root cause of the globe icon appearing on all nav items — Material's instant-navigation JS compared all internal hrefs against the wrong origin and flagged them as external. |
| `docs/overrides/.gitkeep` | Added sentinel file so Git tracks the empty `overrides/` directory. Without this the directory was missing after a fresh CI checkout, causing `mkdocs build` to abort with `custom_dir does not exist`. |
| `docs/stylesheets/extra.css` | Added CSS rules to hide Material's auto-injected `svg.md-icon` globe from the primary sidebar, TOC sidebar, and mobile drawer. Belt-and-suspenders fix alongside the `site_url` correction. |
| `.github/workflows/docs.yml` | Added `feat/doc-site-update` to the branch trigger list; conditioned the Pages upload/deploy jobs to only run on `main` so feature branch builds validate without trying to deploy. Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`. |
| `.github/workflows/docker-publish.yml` | Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to existing `env` block. |
| `.github/workflows/release.yml` | Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env block. |

## How to Test

1. Merge this PR and trigger a deployment to `nexus.developers.prescottdata.io`
2. Open any page — sidebar nav items and TOC headings should have **no globe icon** on internal links
3. Verify the three intentional external Home links (Website, Community, Blog) still show their custom icons (globe, Discord, RSS)
4. Confirm the CI `Build` job passes on this branch without the `custom_dir does not exist` error
5. Confirm no Node.js 20 deprecation warnings appear in any workflow run

## Migration / Breaking Changes

- [ ] Database migration required
- [x] No migration required

> **Note:** `site_url` change affects how MkDocs resolves canonical URLs and sitemap entries. The old GitHub Pages URL (`prescott-data.github.io/nexus-framework`) is no longer the canonical — ensure any external links or search engine indexing points to `nexus.developers.prescottdata.io`.

## Checklist
- [x] Commit messages use present tense, imperative mood, ≤72 chars
- [x] Documentation updated where applicable
- [x] No secrets or credentials committed
- [ ] Code follows the Go styleguide (`gofmt` applied) — *N/A, no Go changes in this PR*