### PR TITLE
fix(css): hide globe only on external nav links (target=_blank); rest…

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -773,33 +773,14 @@ body,
 
 
 /* ============================================================
-   HIDE MATERIAL'S BUILT-IN GLOBE / EXTERNAL-LINK ICON
-   Material injects an inline <svg> globe on every nav link
-   pointing to an external URL — sidebar items AND TOC headings.
-   We already have purpose-built ::before icons for the three
-   Home links (Website, Community, Blog), so suppress the
-   auto-injected globe everywhere else.
+   HIDE MATERIAL'S GLOBE ICON ON EXTERNAL NAV LINKS ONLY
+   Material injects a .md-nav__icon globe SVG on every nav link
+   that opens in a new tab (external URLs). Internal page links
+   have frontmatter icons (icon: material/...) using the same
+   .md-nav__icon structure — we must NOT hide those.
+   Targeting [target="_blank"] isolates only the external links.
    ============================================================ */
-
-/* Left sidebar — primary nav tree */
-.md-nav--primary .md-nav__link > svg.md-icon,
-.md-nav--primary .md-nav__link > .md-ellipsis > svg.md-icon {
-  display: none !important;
-}
-
-/* Right sidebar — table of contents */
-.md-nav--secondary .md-nav__link > svg.md-icon,
-.md-nav--secondary .md-nav__link > .md-ellipsis > svg.md-icon {
-  display: none !important;
-}
-
-/* Mobile drawer */
-.md-nav--integrated .md-nav__link > svg.md-icon {
-  display: none !important;
-}
-
-/* Broad catch-all for any remaining injected SVG globe in sidebars */
-.md-sidebar .md-nav__link > svg[viewBox] {
+.md-nav__link[target="_blank"] .md-nav__icon {
   display: none !important;
 }
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes two issues with the Nexus documentation site (`nexus.developers.prescottdata.io`):

1. **Build failure** — `mkdocs build` was aborting with `custom_dir does not exist` because the empty `docs/overrides/` directory wasn't tracked by Git. Added `.gitkeep` to fix this.
2. **Globe icon on every nav item** — MkDocs Material's instant-navigation JS compares all nav hrefs against `site_url` to determine if a link is external. The configured `site_url` pointed to the old GitHub Pages URL (`prescott-data.github.io/nexus-framework`) instead of the actual deployed domain, so every internal link was flagged as external and got a globe icon. Fixed by correcting `site_url` + a CSS rule that hides the globe on genuinely external links only (scoped to `[target="_blank"]` to avoid hiding legitimate frontmatter page icons).

Also modernises all three CI workflows to opt into Node.js 24 ahead of the GitHub Actions forced cutover on June 2, 2026.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactor

## Changes Made

| File | Summary |
|---|---|
| `mkdocs.yml` | Changed `site_url` from `prescott-data.github.io/nexus-framework` → `nexus.developers.prescottdata.io`. Root cause of the globe icon regression. |
| `docs/overrides/.gitkeep` | Sentinel file so Git tracks the empty `overrides/` directory. Without it, CI checkout omits the folder and `mkdocs build` aborts. |
| `docs/stylesheets/extra.css` | Added `.md-nav__link[target="_blank"] .md-nav__icon { display: none }` — hides the auto-injected globe icon only on external links, preserving all frontmatter page icons (`icon: material/...`) on internal links. |
| `.github/workflows/docs.yml` | Added `feat/doc-site-update` to branch trigger; conditioned Pages deploy to `main` only; added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true`. |
| `.github/workflows/docker-publish.yml` | Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to existing `env` block. |
| `.github/workflows/release.yml` | Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env block. |

## How to Test

1. Merge and trigger a deployment to `nexus.developers.prescottdata.io`
2. Open any internal page (e.g. `/concepts/broker/`) — the sidebar should show the page's frontmatter icon (database lock) with **no globe icon** alongside it
3. Expand the **Home** section in the sidebar — the Website, Community, and Blog external links should show **no globe** (hidden by CSS) while still having their custom `::before` icons (globe, Discord, RSS)
4. Check the Table of Contents panel on any page — no globe icons on any heading
5. Confirm the CI `Build` job on this branch passes without the `custom_dir does not exist` error
6. Confirm no Node.js 20 deprecation warnings in any workflow run

## Migration / Breaking Changes

- [ ] Database migration required
- [x] No migration required

> **Note:** `site_url` is now set to the canonical deployed domain. If you ever move the site back to GitHub Pages at the old URL, revert this value.

## Checklist
- [x] Commit messages use present tense, imperative mood, ≤72 chars
- [x] Documentation updated where applicable
- [x] No secrets or credentials committed
- [ ] Code follows the Go styleguide — *N/A, no Go changes in this PR*