### PR TITLE
fix(gateway): add PATCH to CORS allowed methods

### DIFF
--- a/nexus-gateway/pkg/server/server.go
+++ b/nexus-gateway/pkg/server/server.go
@@ -29,7 +29,7 @@ func New(port, brokerBaseURL string, stateKey []byte, httpClient *http.Client, r
 	// CORS Setup
 	mux.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   config.GetAllowedOrigins(),
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,


### PR DESCRIPTION
PATCH was registered as a route but missing from the CORS AllowedMethods list, causing browsers to block preflight requests for PATCH calls.

# Pull Request

## Description
  The gateway's CORS configuration was missing PATCH from the AllowedMethods list. The route PATCH /v1/providers/{id} was registered
  and functional server-side, but browsers send an OPTIONS preflight for PATCH requests — which the CORS middleware was rejecting.
  This caused any frontend call to PATCH /v1/providers/{id} to fail with a network error before even reaching the server.

## Type of Change
- [ ✅] Bug fix

## Changes Made
- nexus-gateway/pkg/server/server.go — Added "PATCH" to the AllowedMethods slice in the CORS handler options.

## How to Test
<!-- Step-by-step instructions to verify the change works as expected. -->

1. 
2. 

## Migration / Breaking Changes
<!-- Does this require a database migration, config change, or affect existing integrations? -->

- [ ] Database migration required — include the migration file path
- [ ✅] No migration required

## Checklist
- [✅ ] Code follows the Go styleguide (`gofmt` applied)
- [ ✅] Commit messages use present tense, imperative mood, ≤72 chars
- [✅ ] Documentation updated where applicable
- [ ✅] No secrets or credentials committed
