### PR TITLE
fix(broker): auto-refresh expired OAuth2 tokens and deactivate stale …

### DIFF
--- a/nexus-broker/internal/repository/instrumented/instrumented.go
+++ b/nexus-broker/internal/repository/instrumented/instrumented.go
@@ -93,6 +93,11 @@ func (r *ConnectionRepository) ListByWorkspace(ctx context.Context, workspaceID 
 	return r.inner.ListByWorkspace(ctx, workspaceID)
 }
 
+func (r *ConnectionRepository) DeactivateOtherActive(ctx context.Context, workspaceID string, providerID uuid.UUID, exceptID uuid.UUID) error {
+	defer observe("connection", "DeactivateOtherActive", time.Now())
+	return r.inner.DeactivateOtherActive(ctx, workspaceID, providerID, exceptID)
+}
+
 // InTx forwards transactional execution when the wrapped repository supports it.
 func (r *ConnectionRepository) InTx(ctx context.Context, fn func(context.Context) error) error {
 	if runner, ok := r.inner.(txRunner); ok {

--- a/nexus-broker/internal/repository/interfaces.go
+++ b/nexus-broker/internal/repository/interfaces.go
@@ -19,6 +19,9 @@ type ConnectionRepository interface {
 	GetForHealthCheck(ctx context.Context, limit int) ([]*domain.ConnectionWithProvider, error)
 	UpdateHealthStatus(ctx context.Context, id uuid.UUID, status string) error
 	ListByWorkspace(ctx context.Context, workspaceID string) ([]domain.ConnectionSummary, error)
+	// DeactivateOtherActive marks all active connections for the same workspace+provider
+	// as "superseded", excluding the connection that just became active.
+	DeactivateOtherActive(ctx context.Context, workspaceID string, providerID uuid.UUID, exceptID uuid.UUID) error
 }
 
 // TokenRepository handles database operations for tokens

--- a/nexus-broker/internal/repository/postgres/connection.go
+++ b/nexus-broker/internal/repository/postgres/connection.go
@@ -170,9 +170,21 @@ func (r *connectionRepository) GetForHealthCheck(ctx context.Context, limit int)
 	return ptrRows, nil
 }
 
+func (r *connectionRepository) DeactivateOtherActive(ctx context.Context, workspaceID string, providerID uuid.UUID, exceptID uuid.UUID) error {
+	_, err := execerFromContext(ctx, r.db).ExecContext(ctx, `
+		UPDATE connections
+		SET status = 'superseded', updated_at = NOW()
+		WHERE workspace_id = $1
+		  AND provider_id = $2
+		  AND id != $3
+		  AND status = 'active'`,
+		workspaceID, providerID, exceptID)
+	return err
+}
+
 func (r *connectionRepository) UpdateHealthStatus(ctx context.Context, id uuid.UUID, status string) error {
 	_, err := execerFromContext(ctx, r.db).ExecContext(ctx, `
-		UPDATE connections 
+		UPDATE connections
 		SET health_status = $1, last_health_check_at = NOW(), updated_at = NOW()
 		WHERE id = $2`, status, id)
 	return err

--- a/nexus-broker/internal/service/connection.go
+++ b/nexus-broker/internal/service/connection.go
@@ -320,6 +320,9 @@ func (s *connectionService) ExchangeCodeForTokens(ctx context.Context, state, co
 		if err := s.connRepo.UpdateStatus(txCtx, connID, "active"); err != nil {
 			return ErrInternalWithErr(err, "status_update_failed", "Failed to update status")
 		}
+		if err := s.connRepo.DeactivateOtherActive(txCtx, stateData.WorkspaceID, conn.ProviderID, connID); err != nil {
+			return ErrInternalWithErr(err, "deactivate_stale_failed", "Failed to deactivate stale connections")
+		}
 		return nil
 	}); err != nil {
 		return "", false, err
@@ -385,6 +388,25 @@ func (s *connectionService) GetToken(ctx context.Context, connectionID uuid.UUID
 	var credentials map[string]interface{}
 	if err := json.Unmarshal(decryptedData, &credentials); err != nil {
 		return nil, "", ErrInternalWithErr(err, "invalid_token_format", "Invalid token format")
+	}
+
+	if token.ExpiresAt != nil && token.ExpiresAt.Before(time.Now()) {
+		if conn.AuthType == "oauth2" || conn.AuthType == "" {
+			if _, refreshErr := s.Refresh(ctx, connectionID); refreshErr != nil {
+				return nil, "", ErrConflict("token_expired", "Token has expired and could not be refreshed. Re-authentication is required.")
+			}
+			token, err = s.tokenRepo.Get(ctx, connectionID)
+			if err != nil {
+				return nil, "", ErrInternalWithErr(err, "token_not_found", "Failed to fetch refreshed token")
+			}
+			decryptedData, err = vault.Decrypt(s.encryptionKey, token.EncryptedData)
+			if err != nil {
+				return nil, "", ErrInternalWithErr(err, "decrypt_failed", "Failed to decrypt refreshed token")
+			}
+			if err = json.Unmarshal(decryptedData, &credentials); err != nil {
+				return nil, "", ErrInternalWithErr(err, "invalid_token_format", "Invalid refreshed token format")
+			}
+		}
 	}
 
 	if token.ExpiresAt != nil {

--- a/nexus-broker/internal/service/connection_health_test.go
+++ b/nexus-broker/internal/service/connection_health_test.go
@@ -64,6 +64,11 @@ func (m *MockConnectionRepository) UpdateHealthStatus(ctx context.Context, id uu
 	return args.Error(0)
 }
 
+func (m *MockConnectionRepository) DeactivateOtherActive(ctx context.Context, workspaceID string, providerID uuid.UUID, exceptID uuid.UUID) error {
+	args := m.Called(ctx, workspaceID, providerID, exceptID)
+	return args.Error(0)
+}
+
 // MockConnectionService mocks the ConnectionService
 type MockConnectionService struct {
 	mock.Mock

--- a/nexus-broker/internal/service/connection_test.go
+++ b/nexus-broker/internal/service/connection_test.go
@@ -417,6 +417,7 @@ func TestConnectionService_SaveCredential(t *testing.T) {
 		return t.ConnectionID == connID && t.EncryptedData != ""
 	})).Return(nil)
 	connRepo.On("UpdateStatus", mock.Anything, connID, "active").Return(nil)
+	connRepo.On("DeactivateOtherActive", mock.Anything, "ws-test", providerID, connID).Return(nil)
 
 	credentials := map[string]interface{}{"api_key": "my-secret-key"}
 	returnURL, err := svc.SaveCredential(context.Background(), signedState, credentials)
@@ -653,6 +654,7 @@ func TestConnectionService_ExchangeCodeForTokens_Success(t *testing.T) {
 
 	// Mock status update
 	connRepo.On("UpdateStatus", mock.Anything, connID, "active").Return(nil)
+	connRepo.On("DeactivateOtherActive", mock.Anything, "ws-exchange", providerID, connID).Return(nil)
 
 	returnURL, _, err := svc.ExchangeCodeForTokens(context.Background(), signedState, "auth-code-xyz", "", "")
 

--- a/nexus-broker/internal/service/credential.go
+++ b/nexus-broker/internal/service/credential.go
@@ -94,6 +94,9 @@ func (s *connectionService) SaveCredential(ctx context.Context, state string, cr
 		if err := s.connRepo.UpdateStatus(txCtx, connID, "active"); err != nil {
 			return ErrInternalWithErr(err, "status_update_failed", "Failed to update status")
 		}
+		if err := s.connRepo.DeactivateOtherActive(txCtx, stateData.WorkspaceID, conn.ProviderID, connID); err != nil {
+			return ErrInternalWithErr(err, "deactivate_stale_failed", "Failed to deactivate stale connections")
+		}
 		return nil
 	}); err != nil {
 		return "", err

--- a/nexus-broker/pkg/handlers/soc2_compliance_test.go
+++ b/nexus-broker/pkg/handlers/soc2_compliance_test.go
@@ -104,6 +104,10 @@ func TestSOC2_CC61_EncryptionAtRest(t *testing.T) {
 	mock.ExpectExec("UPDATE connections SET status").
 		WithArgs("active", connID).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	mock.ExpectExec("UPDATE connections").
+		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 0))
 	mock.ExpectCommit()
 
 	// 3. Fire the request


### PR DESCRIPTION
## Description

Fixes the root cause of expired OAuth2 tokens being served to downstream providers (e.g. Google Drive returning 401). The broker was detecting token expiry but returning the stale token anyway with no attempt to refresh. Additionally, reconnecting a provider left orphaned `active` connections in the database that could interfere with token resolution.

## Type of Change
- [x] Bug fix

## Changes Made

| File | Change |
|------|--------|
| `internal/service/connection.go` | `GetToken` now auto-refreshes expired OAuth2 tokens before returning. Returns `409 token_expired` if the refresh grant fails instead of serving stale credentials |
| `internal/service/credential.go` | `SaveCredential` deactivates other active connections for the same workspace+provider within the activation transaction |
| `internal/service/connection.go` | `ExchangeCodeForTokens` does the same — marks prior active connections as `superseded` when a new OAuth2 connection goes active |
| `internal/repository/interfaces.go` | Adds `DeactivateOtherActive` to `ConnectionRepository` interface |
| `internal/repository/postgres/connection.go` | Implements `DeactivateOtherActive` — single `UPDATE` setting `status = 'superseded'` for stale peers |
| `internal/repository/instrumented/instrumented.go` | Wraps `DeactivateOtherActive` with Prometheus latency instrumentation |
| `internal/service/connection_test.go` | Adds mock method and expectation for `DeactivateOtherActive` in `SaveCredential` and `ExchangeCodeForTokens` tests |
| `internal/service/connection_health_test.go` | Adds `DeactivateOtherActive` to `MockConnectionRepository` |
| `pkg/handlers/soc2_compliance_test.go` | Adds sqlmock `UPDATE connections` expectation for the new deactivation query |

## How to Test

1. Connect a Google Drive account and note the `connection_id`
2. Wait for the token to expire (or manually set `expires_at` to the past in the DB)
3. Call `GET /connections/{connectionId}/token` — confirm it returns a valid, refreshed token (not a 401)
4. Connect the same Google Drive account again (reconnect flow)
5. Query the DB — confirm the old connection has `status = 'superseded'` and only the new one is `active`
6. Call `GET /connections/resolve?workspace_id=...&provider_name=google-drive` — confirm it resolves to the new connection

## Migration / Breaking Changes

- [x] No migration required

The new `superseded` connection status is additive. Existing queries that filter by `status = 'active'` are unaffected. The `ListByWorkspace` endpoint already returns all non-`pending` statuses, so superseded connections will appear in connection history.

## Checklist
- [x] Code follows the Go styleguide (`gofmt` applied)
- [x] Commit messages use present tense, imperative mood, ≤72 chars
- [x] Documentation updated where applicable
- [x] No secrets or credentials committed