### PR TITLE
fix(broker): distinguish credential-validation failures by cause

### DIFF
--- a/nexus-broker/internal/service/credential.go
+++ b/nexus-broker/internal/service/credential.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"strings"
@@ -79,13 +80,13 @@ func (s *connectionService) SaveCredential(ctx context.Context, state string, cr
 				"Provider is not configured for credential validation (missing api_base_url or user_info_endpoint)")
 		}
 		if err := s.validateCredentials(ctx, conn.AuthType, conn.AuthHeader, conn.APIBaseURL, conn.UserInfoEndpoint, credentials); err != nil {
-			return "", ErrBadRequestWithErr(err, "invalid_credentials", "Invalid credentials")
+			return "", err
 		}
 	default:
 		// Other auth types keep best-effort validation when an endpoint is configured.
 		if conn.UserInfoEndpoint != "" && conn.APIBaseURL != "" {
 			if err := s.validateCredentials(ctx, conn.AuthType, conn.AuthHeader, conn.APIBaseURL, conn.UserInfoEndpoint, credentials); err != nil {
-				return "", ErrBadRequestWithErr(err, "invalid_credentials", "Invalid credentials")
+				return "", err
 			}
 		}
 	}
@@ -226,14 +227,14 @@ func (s *connectionService) validateCredentials(ctx context.Context, authType, a
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, testURL, nil)
 	if err != nil {
-		return fmt.Errorf("could not build validation request")
+		return ErrInternalWithErr(err, "validation_request_failed", "Could not build credential-validation request")
 	}
 
 	switch authType {
 	case "api_key":
 		apiKey, _ := credentials["api_key"].(string)
 		if apiKey == "" {
-			return fmt.Errorf("api_key credential is required")
+			return ErrBadRequest("missing_credential", "The 'api_key' credential is required")
 		}
 		headerName := authHeader
 		if headerName == "" {
@@ -248,6 +249,9 @@ func (s *connectionService) validateCredentials(ctx context.Context, authType, a
 	case "basic_auth":
 		username, _ := credentials["username"].(string)
 		password, _ := credentials["password"].(string)
+		if username == "" && password == "" {
+			return ErrBadRequest("missing_credential", "The 'username' and 'password' credentials are required")
+		}
 		encoded := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 		req.Header.Set("Authorization", "Basic "+encoded)
 
@@ -257,12 +261,16 @@ func (s *connectionService) validateCredentials(ctx context.Context, authType, a
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("could not reach provider to validate credentials")
+		// The broker could not reach the provider — this is NOT a credential
+		// rejection. Surface it distinctly (502, logged) so it is not confused
+		// with a bad key (e.g. missing egress from the broker to the provider).
+		log.Printf("validateCredentials: could not reach provider at %s: %v", testURL, err)
+		return ErrBadGatewayWithErr(err, "validation_unreachable", "Could not reach the provider to validate the credentials")
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return fmt.Errorf("credentials rejected by provider")
+		return ErrBadRequest("credentials_rejected", "The provider rejected these credentials")
 	}
 
 	return nil

--- a/nexus-broker/internal/service/errors.go
+++ b/nexus-broker/internal/service/errors.go
@@ -62,3 +62,11 @@ func ErrInternalWithErr(err error, code, message string) *ServiceError {
 func ErrConflict(code, message string) *ServiceError {
 	return NewServiceError(http.StatusConflict, nil, code, message)
 }
+
+// ErrBadGatewayWithErr is for failures reaching an upstream provider (e.g. the
+// broker cannot reach a provider's API to validate a credential). Status 502 so
+// the cause is logged by writeServiceError and clients can distinguish it from
+// a genuine credential rejection.
+func ErrBadGatewayWithErr(err error, code, message string) *ServiceError {
+	return NewServiceError(http.StatusBadGateway, err, code, message)
+}


### PR DESCRIPTION
# Pull Request

## Description

`SaveCredential` no longer collapses every credential-validation failure into a
single `invalid_credentials` response. `validateCredentials` now returns distinct,
logged errors so the real reason is visible in logs and to clients:

- **`credentials_rejected`** (400) — the provider returned `401`/`403` (genuinely bad key)
- **`validation_unreachable`** (502) — the broker could not reach the provider's API to
  validate (e.g. missing egress from the broker to the provider host); logged with the
  target URL and underlying cause
- **`missing_credential`** (400) — required credential field(s) not supplied
- **`validation_request_failed`** (500) — the validation request could not be built

Previously all four looked identical (`invalid_credentials`, 400) and, because
`writeServiceError` only logs a cause for `>=500` responses, an unreachable-provider
failure was completely invisible — making issues like a Twilio connection failing due
to broker egress impossible to diagnose.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor

## Changes Made

- **`nexus-broker/internal/service/credential.go`**
  - `SaveCredential` now propagates the typed errornstead
    of wrapping every failure as `invalid_credentials`.
  - `validateCredentials` returns typed `ServiceErr
    `validation_unreachable`, `missing_credential`, `validation_request_failed`) and
    logs a line when the provider is unreachable (`url>: <err>`).
  - `basic_auth` now returns `missing_credential` when both `username` and `password`
    are empty (instead of validating an empty `:` p
- **`nexus-broker/internal/service/errors.go`**
  - Added `ErrBadGatewayWithErr` (HTTP 502) so unrery a
    distinct status and are logged by the existing `writeServiceError` (`>=500`) path.

## How to Test

1. **Rejected key:** register an `api_key`/`basic_auth` provider with a valid
   `api_base_url` + `user_info_endpoint`; run captuy →
   expect `credentials_rejected` (400), not `invalid_credentials`.
2. **Valid key:** run capture-credential with a cor `active`.
3. **Unreachable provider:** point `api_base_url` at an unroutable host (or block egress)
   and run capture-credential → expect `validation_er log line
   `validateCredentials: could not reach provider at <url>: <err>`.
4. **Missing fields:** submit empty credentials → e00).
5. `go build ./... && go test ./internal/service/... ./pkg/handlers/...` — all pass.

## Migration / Breaking Changes

No DB migration. **API contract change (non-breaking for behavior, but error codes changed):**
clients that matched on the literal code `invalid_cntial
failures should now handle `credentials_rejected` / `validation_unreachable` /
`missing_credential` / `validation_request_failed`.d to map
these (doc-intel-dashboard `fix/workflow-bug`, commit `136938e`).

- [ ] Database migration required — include the migration file path
- [x] No migration required

## Checklist
- [x] Code follows the Go styleguide (`gofmt` applied)
- [x] Commit messages use present tense, imperative
- [x] Documentation updated where applicable
- [x] No secrets or credentials committed