### PR TITLE
fix(broker): never serve credential validation from the response cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,13 @@ ALLOWED_RETURN_DOMAINS=localhost,127.0.0.1
 REQUIRE_API_KEY=true
 REQUIRE_ALLOWLIST=false
 
+# Credential-validation probes refuse to dial private, loopback, link-local and
+# other non-publicly-routable addresses, because the probe URL is partly
+# user-supplied for self-hosted providers (SSRF guard).
+# Set to "true" ONLY for local development against a stub provider on
+# 127.0.0.1. Never set this in a deployed environment.
+NEXUS_ALLOW_PRIVATE_PROBE_TARGETS=false
+
 # --- Gateway Configuration ---
 PORT_GATEWAY=8090
 BROKER_BASE_URL=http://broker:8080

--- a/nexus-broker/internal/service/connection.go
+++ b/nexus-broker/internal/service/connection.go
@@ -90,7 +90,7 @@ func NewConnectionService(
 		encryptionKey:        encryptionKey,
 		stateKey:             stateKey,
 		httpClient:           httpClient,
-		probeClient:          &http.Client{Timeout: 15 * time.Second},
+		probeClient:          newProbeClient(),
 		enforceReturnURL:     enforceReturnURL,
 		allowedReturnDomains: allowedReturnDomains,
 	}

--- a/nexus-broker/internal/service/connection.go
+++ b/nexus-broker/internal/service/connection.go
@@ -35,15 +35,18 @@ type ConnectionService interface {
 }
 
 type connectionService struct {
-	connRepo             repository.ConnectionRepository
-	tokenRepo            repository.TokenRepository
-	providerStore        provider.ProfileStorer
-	audit                audit.Logger
-	baseURL              string
-	redirectPath         string
-	encryptionKey        []byte
-	stateKey             []byte
-	httpClient           *http.Client
+	connRepo      repository.ConnectionRepository
+	tokenRepo     repository.TokenRepository
+	providerStore provider.ProfileStorer
+	audit         audit.Logger
+	baseURL       string
+	redirectPath  string
+	encryptionKey []byte
+	stateKey      []byte
+	httpClient    *http.Client
+	// probeClient is a plain, uncached client reserved for credential-validation
+	// probes. See validationClient() for why these must bypass httpClient.
+	probeClient          *http.Client
 	enforceReturnURL     bool
 	allowedReturnDomains []string
 }
@@ -87,6 +90,7 @@ func NewConnectionService(
 		encryptionKey:        encryptionKey,
 		stateKey:             stateKey,
 		httpClient:           httpClient,
+		probeClient:          &http.Client{Timeout: 15 * time.Second},
 		enforceReturnURL:     enforceReturnURL,
 		allowedReturnDomains: allowedReturnDomains,
 	}

--- a/nexus-broker/internal/service/connection_test.go
+++ b/nexus-broker/internal/service/connection_test.go
@@ -299,8 +299,8 @@ func TestConnectionService_GetToken_Active(t *testing.T) {
 	expiresAt := time.Now().Add(1 * time.Hour)
 	tokenData := map[string]interface{}{"access_token": "super-secret-token"}
 	tokenBytes, _ := json.Marshal(tokenData)
-	
-	encryptionKey := []byte("12345678901234567890123456789012") 
+
+	encryptionKey := []byte("12345678901234567890123456789012")
 	encryptedData, _ := vault.Encrypt(encryptionKey, tokenBytes)
 
 	token := &domain.Token{
@@ -316,7 +316,7 @@ func TestConnectionService_GetToken_Active(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
-	
+
 	strategy := resp["strategy"].(map[string]interface{})
 	assert.Equal(t, "oauth2", strategy["type"])
 
@@ -356,6 +356,12 @@ func TestConnectionService_GetToken_NotActive(t *testing.T) {
 // --- setupTestServiceWithHTTPClient creates a service with a custom HTTP client (for mock servers) ---
 
 func setupTestServiceWithHTTPClient(t *testing.T, httpClient *http.Client) (*MockConnectionRepository, *MockTokenRepository, *MockProfileStorer, service.ConnectionService, []byte) {
+	// Credential-validation probes refuse to dial non-public addresses (SSRF
+	// guard, see service.newProbeClient). Callers here point the provider at an
+	// httptest stub on 127.0.0.1, so opt out explicitly rather than depending on
+	// the guard being absent.
+	t.Setenv(service.AllowPrivateProbeTargetsEnv, "true")
+
 	connRepo := new(MockConnectionRepository)
 	tokenRepo := new(MockTokenRepository)
 	providerStore := new(MockProfileStorer)

--- a/nexus-broker/internal/service/credential.go
+++ b/nexus-broker/internal/service/credential.go
@@ -246,6 +246,23 @@ func (s *connectionService) Refresh(ctx context.Context, connectionID uuid.UUID)
 	}
 }
 
+// validationClient returns the HTTP client used for credential-validation
+// probes.
+//
+// These MUST NOT go through the shared caching client: cachingTransport keys
+// responses on the request URL alone, so the Authorization header is invisible
+// to it. A probe with a valid credential would then satisfy every later probe
+// for the same endpoint regardless of the credential supplied — accepting
+// arbitrary keys for the whole TTL — and conversely a cached 401 would reject
+// valid credentials. Probes are per-credential and must always hit the provider.
+func (s *connectionService) validationClient() *http.Client {
+	if s.probeClient != nil {
+		return s.probeClient
+	}
+	// Tests construct connectionService directly with only httpClient set.
+	return s.httpClient
+}
+
 func (s *connectionService) validateCredentials(ctx context.Context, authType, authHeader, apiBaseURL, userInfoEndpoint string, providerParams *json.RawMessage, credentials map[string]interface{}) error {
 	// Self-hosted / instance-specific providers have no global api_base_url; the
 	// user supplies their instance URL at connect time (stored as "base_url").
@@ -275,7 +292,7 @@ func (s *connectionService) validateCredentials(ctx context.Context, authType, a
 		return err
 	}
 
-	resp, err := s.httpClient.Do(req)
+	resp, err := s.validationClient().Do(req)
 	if err != nil {
 		// The broker could not reach the provider — this is NOT a credential
 		// rejection. Surface it distinctly (502, logged) so it is not confused

--- a/nexus-broker/internal/service/probe_client.go
+++ b/nexus-broker/internal/service/probe_client.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Credential-validation probes are the one place where a connecting user
+// controls the URL the broker fetches: self-hosted providers have no global
+// api_base_url, so the instance URL arrives as the user's "base_url" credential
+// (see effectiveBaseURL), and {field} placeholders in the endpoint are filled
+// from user-supplied credentials (see renderEndpoint).
+//
+// Unguarded, that is server-side request forgery. The response body is never
+// returned to the caller, but the outcome is still an oracle: a reachable host
+// answering 401/403 surfaces as "credentials rejected" while an unreachable one
+// surfaces as "validation unreachable", which is enough to map internal hosts
+// and ports from outside the network.
+//
+// The broker is internet-hosted and every legitimate provider — including a
+// customer's self-hosted Jenkins or Mattermost — is reachable over the public
+// internet. It never needs to dial a private, loopback or link-local address,
+// so refusing those costs nothing and closes the hole.
+
+// AllowPrivateProbeTargetsEnv opts out of the guard for local development, where
+// probe targets are typically stubs on 127.0.0.1. It must never be set in a
+// deployed environment; it exists so `docker compose up` remains testable, and
+// so tests that drive the real service against an httptest server can opt in
+// explicitly rather than silently depending on the guard being absent.
+const AllowPrivateProbeTargetsEnv = "NEXUS_ALLOW_PRIVATE_PROBE_TARGETS"
+
+// errBlockedProbeTarget is returned by the dialer for a disallowed address. It
+// reaches the broker log via validateCredentials, while the API response stays
+// the generic "validation_unreachable" so the caller cannot distinguish a
+// blocked address from an unreachable one.
+type errBlockedProbeTarget struct{ addr string }
+
+func (e *errBlockedProbeTarget) Error() string {
+	return fmt.Sprintf("probe target %s is not a publicly routable address", e.addr)
+}
+
+// isPublicProbeTarget reports whether ip may be dialed by a validation probe.
+func isPublicProbeTarget(ip net.IP) bool {
+	if ip == nil {
+		return false
+	}
+	// Normalise IPv4-mapped IPv6 (::ffff:169.254.169.254) to its v4 form so the
+	// checks below cannot be bypassed by expressing the address differently.
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
+
+	switch {
+	case ip.IsUnspecified(), // 0.0.0.0, ::
+		ip.IsLoopback(),                // 127.0.0.0/8, ::1
+		ip.IsPrivate(),                 // RFC1918, fc00::/7
+		ip.IsLinkLocalUnicast(),        // 169.254.0.0/16 (cloud metadata), fe80::/10
+		ip.IsLinkLocalMulticast(),      //
+		ip.IsInterfaceLocalMulticast(), //
+		ip.IsMulticast():
+		return false
+	}
+
+	if v4 := ip.To4(); v4 != nil {
+		// Carrier-grade NAT (100.64.0.0/10): not covered by IsPrivate, not
+		// publicly routable either.
+		if v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+			return false
+		}
+		// 0.0.0.0/8 "this network" — only the exact address is IsUnspecified.
+		if v4[0] == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// newProbeClient builds the HTTP client used for credential-validation probes.
+//
+// The address check runs in Dialer.Control, i.e. after DNS resolution and
+// immediately before connect, against the address actually being dialed. That
+// placement matters: checking the hostname up front would be defeated by DNS
+// rebinding, and checking only the original URL would be defeated by a redirect
+// to an internal address. Every connection — initial and redirected — passes
+// through here.
+//
+// This client is deliberately not the shared caching client; see
+// validationClient() for why probes must never be served from cache.
+func newProbeClient() *http.Client {
+	allowPrivate := strings.EqualFold(strings.TrimSpace(os.Getenv(AllowPrivateProbeTargetsEnv)), "true")
+
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+	if !allowPrivate {
+		dialer.Control = func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return &errBlockedProbeTarget{addr: address}
+			}
+			if ip := net.ParseIP(host); ip == nil || !isPublicProbeTarget(ip) {
+				return &errBlockedProbeTarget{addr: host}
+			}
+			return nil
+		}
+	}
+
+	return &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.DialContext(ctx, network, addr)
+			},
+			TLSHandshakeTimeout:   10 * time.Second,
+			ResponseHeaderTimeout: 10 * time.Second,
+			MaxIdleConnsPerHost:   2,
+		},
+	}
+}

--- a/nexus-broker/internal/service/probe_client_test.go
+++ b/nexus-broker/internal/service/probe_client_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsPublicProbeTarget(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1",       // loopback
+		"127.1.2.3",       // rest of 127.0.0.0/8
+		"::1",             // IPv6 loopback
+		"0.0.0.0",         // unspecified
+		"0.1.2.3",         // 0.0.0.0/8
+		"10.0.0.5",        // RFC1918
+		"172.16.4.4",      // RFC1918
+		"192.168.1.1",     // RFC1918
+		"169.254.169.254", // cloud metadata
+		"fe80::1",         // IPv6 link-local
+		"fc00::1",         // IPv6 unique-local
+		"100.64.0.1",      // carrier-grade NAT
+		"100.127.255.254", // upper end of CGNAT
+		"224.0.0.1",       // multicast
+		// IPv4-mapped IPv6 forms must not slip past the v4 checks.
+		"::ffff:127.0.0.1",
+		"::ffff:169.254.169.254",
+		"::ffff:10.0.0.1",
+	}
+	for _, s := range blocked {
+		if isPublicProbeTarget(net.ParseIP(s)) {
+			t.Errorf("%s should be blocked as a probe target", s)
+		}
+	}
+
+	allowed := []string{
+		"8.8.8.8",
+		"1.1.1.1",
+		"140.82.121.4",    // github
+		"2606:4700::1111", // public IPv6
+		"100.63.255.255",  // just below CGNAT
+		"100.128.0.1",     // just above CGNAT
+		"172.32.0.1",      // just outside 172.16/12
+		"11.0.0.1",        // just outside 10/8
+	}
+	for _, s := range allowed {
+		if !isPublicProbeTarget(net.ParseIP(s)) {
+			t.Errorf("%s should be allowed as a probe target", s)
+		}
+	}
+
+	if isPublicProbeTarget(nil) {
+		t.Error("nil IP must not be treated as a valid probe target")
+	}
+}
+
+// The guard must apply at dial time, not merely as a string check on the URL,
+// so that DNS rebinding and redirects to internal addresses are covered too.
+func TestProbeClient_BlocksLoopbackDial(t *testing.T) {
+	t.Setenv(AllowPrivateProbeTargetsEnv, "")
+
+	var reached bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// httptest listens on 127.0.0.1, standing in for any internal host a
+	// connecting user might point base_url at.
+	if _, err := newProbeClient().Get(srv.URL); err == nil {
+		t.Fatal("probe client dialed a loopback address; SSRF guard is not applied")
+	}
+	if reached {
+		t.Fatal("request reached the blocked target")
+	}
+}
+
+// Local development needs an opt-out, and it must be opt-in only.
+func TestProbeClient_AllowsPrivateWhenExplicitlyEnabled(t *testing.T) {
+	t.Setenv(AllowPrivateProbeTargetsEnv, "true")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	resp, err := newProbeClient().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("opt-out should permit private targets: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status %d", resp.StatusCode)
+	}
+}
+
+// A typo or a truthy-looking value must not silently disable the guard.
+func TestProbeClient_OptOutRequiresExactTrue(t *testing.T) {
+	for _, tc := range []struct {
+		value       string
+		wantAllowed bool
+	}{
+		{"", false},
+		{"1", false},
+		{"yes", false},
+		{"false", false},
+		{"true", true},
+		{"TRUE ", true}, // trimmed and case-folded
+	} {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			t.Setenv(AllowPrivateProbeTargetsEnv, tc.value)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			defer srv.Close()
+
+			resp, err := newProbeClient().Get(srv.URL)
+			if resp != nil {
+				resp.Body.Close()
+			}
+			if tc.wantAllowed && err != nil {
+				t.Fatalf("%q should enable the opt-out: %v", tc.value, err)
+			}
+			if !tc.wantAllowed && err == nil {
+				t.Fatalf("%q must not enable the opt-out", tc.value)
+			}
+		})
+	}
+}

--- a/nexus-broker/internal/service/validation_cache_test.go
+++ b/nexus-broker/internal/service/validation_cache_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Prescott-Data/nexus-framework/nexus-broker/pkg/caching"
+)
+
+// A credential-validation probe must reach the provider on every attempt.
+//
+// Regression test for a fail-open found during end-to-end testing: the broker
+// passed its shared caching client (main.go -> NewConnectionService) to
+// validateCredentials. cachingTransport keys responses on the request URL alone,
+// so the Authorization header was invisible to the cache. Once any valid
+// credential had been validated against an endpoint, every subsequent probe for
+// that URL was served the cached 200 — accepting arbitrary credentials for the
+// full cache TTL — and a cached 401 conversely rejected valid ones.
+func TestValidateCredentials_ProbeIsNeverCached(t *testing.T) {
+	var probes int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probes++
+		user, pass, _ := r.BasicAuth()
+		if user == "admin" && pass == "good" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	params := rawParams(t, map[string]interface{}{
+		"auth_strategy": map[string]interface{}{
+			"type":   "basic_auth",
+			"config": map[string]interface{}{"username_field": "username", "password_field": "password"},
+		},
+	})
+
+	svc := &connectionService{probeClient: srv.Client()}
+
+	good := map[string]interface{}{"username": "admin", "password": "good"}
+	if err := svc.validateCredentials(context.Background(), "basic_auth", "", srv.URL, "/me", params, good); err != nil {
+		t.Fatalf("valid credential should pass: %v", err)
+	}
+
+	// Same URL, different credential. This must be probed again, not served
+	// from a previous result.
+	bad := map[string]interface{}{"username": "admin", "password": "WRONG"}
+	if err := svc.validateCredentials(context.Background(), "basic_auth", "", srv.URL, "/me", params, bad); err == nil {
+		t.Fatal("invalid credential was accepted — validation result was reused across credentials")
+	}
+
+	if probes != 2 {
+		t.Fatalf("expected the provider to be probed once per attempt, got %d probes", probes)
+	}
+}
+
+// The shared caching transport must not store responses to credentialed
+// requests at all: the key is URL-only, so a cached authenticated response
+// would be replayed to any other caller of the same URL.
+func TestCachingTransport_DoesNotCacheCredentialedRequests(t *testing.T) {
+	var hits int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		user, pass, _ := r.BasicAuth()
+		if (user == "admin" && pass == "good") || r.Header.Get("X-Api-Key") == "good" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	// A caching client with no Redis behind it: every cache read errors, which
+	// exercises the miss path. What matters is that a credentialed request is
+	// routed straight to the underlying transport and never written to cache —
+	// a nil Redis client would panic on Set if the guard were missing.
+	client := caching.NewCachingClient(nil, 0)
+
+	for _, tc := range []struct {
+		name  string
+		apply func(r *http.Request)
+	}{
+		{"basic auth", func(r *http.Request) { r.SetBasicAuth("admin", "good") }},
+		{"bearer", func(r *http.Request) { r.Header.Set("Authorization", "Bearer good") }},
+		{"custom api key header", func(r *http.Request) { r.Header.Set("X-Api-Key", "good") }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before := hits
+			req, _ := http.NewRequest(http.MethodGet, srv.URL+"/me", nil)
+			tc.apply(req)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("credentialed request should pass through: %v", err)
+			}
+			defer resp.Body.Close()
+			if hits != before+1 {
+				t.Fatal("credentialed request did not reach the origin")
+			}
+		})
+	}
+}

--- a/nexus-broker/pkg/caching/client.go
+++ b/nexus-broker/pkg/caching/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httputil"
+	"strings"
 	"time"
 
 	"github.com/go-redis/redis/v8"
@@ -21,6 +22,16 @@ type cachingTransport struct {
 // RoundTrip implements the http.RoundTripper interface.
 func (t *cachingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Method != "GET" {
+		return t.transport.RoundTrip(req)
+	}
+
+	// Never cache credentialed requests. The cache key below is the URL alone,
+	// so an authenticated response would be replayed to any later caller of the
+	// same URL regardless of who they authenticated as — both a correctness bug
+	// (one principal's credential validating another's) and a disclosure risk
+	// (one principal's response body served to another). Only unauthenticated
+	// GETs — OIDC discovery documents, JWKS — are safe to share.
+	if isCredentialed(req) {
 		return t.transport.RoundTrip(req)
 	}
 
@@ -62,6 +73,27 @@ func (t *cachingTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	return newResp, nil
+}
+
+// isCredentialed reports whether a request carries caller-specific credentials,
+// in which case its response must not enter a URL-keyed shared cache.
+func isCredentialed(req *http.Request) bool {
+	if req.Header.Get("Authorization") != "" || req.Header.Get("Proxy-Authorization") != "" {
+		return true
+	}
+	if len(req.Cookies()) > 0 {
+		return true
+	}
+	// Common non-standard API-key headers used by providers in place of
+	// Authorization (e.g. Shortcut-Token, X-TrackerToken, Api-Token, X-API-KEY).
+	for name := range req.Header {
+		lower := strings.ToLower(name)
+		if strings.Contains(lower, "api-key") || strings.Contains(lower, "apikey") ||
+			strings.Contains(lower, "token") || strings.Contains(lower, "secret") {
+			return true
+		}
+	}
+	return false
 }
 
 // NewCachingClient returns a new http.Client configured with the cachingTransport.

--- a/nexus-broker/pkg/handlers/soc2_compliance_test.go
+++ b/nexus-broker/pkg/handlers/soc2_compliance_test.go
@@ -25,6 +25,12 @@ import (
 // setupSOC2Env initializes a real handler with a real service, wired to a mock database.
 // This allows us to prove end-to-end data flows for compliance auditing.
 func setupSOC2Env(t *testing.T) (*handlers.CallbackHandler, sqlmock.Sqlmock, []byte, *sqlx.DB) {
+	// Credential-validation probes refuse to dial non-public addresses (SSRF
+	// guard, see service.newProbeClient). This suite drives the real service
+	// against an httptest stub on 127.0.0.1, so it opts out explicitly rather
+	// than depending on the guard being absent.
+	t.Setenv(service.AllowPrivateProbeTargetsEnv, "true")
+
 	db, mock, err := sqlmock.New()
 	assert.NoError(t, err)
 
@@ -67,9 +73,9 @@ func setupSOC2Env(t *testing.T) (*handlers.CallbackHandler, sqlmock.Sqlmock, []b
 // they are encrypted before ever touching the database (TSC CC6.1).
 //
 // This test provides two-layer proof:
-//   1. Integration: The handler stores credentials via parameterized SQL (no plaintext in queries)
-//   2. Cryptographic: vault.Encrypt produces ciphertext that does NOT contain plaintext,
-//      and vault.Decrypt recovers the original value.
+//  1. Integration: The handler stores credentials via parameterized SQL (no plaintext in queries)
+//  2. Cryptographic: vault.Encrypt produces ciphertext that does NOT contain plaintext,
+//     and vault.Decrypt recovers the original value.
 func TestSOC2_CC61_EncryptionAtRest(t *testing.T) {
 	handler, mock, stateKey, db := setupSOC2Env(t)
 	defer db.Close()


### PR DESCRIPTION
## Description

Connect-time credential validation ran through the shared Redis-backed caching
client (`main.go` → `NewConnectionService`). `cachingTransport` keys responses on
the request URL alone, so the `Authorization` header is invisible to it: once any
credential had been validated against a provider endpoint, every later probe for
that URL was served the cached response for the full 1h TTL.

Reproduced end to end against a live broker:

- a valid credential's cached 200 then accepted **arbitrary** credentials for that
  provider, with no request to the provider at all
- conversely, a cached 401 rejected **valid** credentials

This defeated fail-closed static-credential validation for every header- and
Basic-auth provider. `query_param`/`path` providers were keyed correctly only by
accident, because their credential is part of the URL — which also means those
credentials were being written into Redis cache keys.

Background health checks were unaffected (`connection_health.go` uses its own
plain client), so bad credentials were still flagged after the fact. That masked
the connect-time hole.

Current staging exposure is limited to the 14 providers that actually validate
today; the other 61 fail earlier with `provider_not_validatable`. That flips the
moment those providers are configured.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

## Changes Made

| File | Summary |
|---|---|
| `nexus-broker/internal/service/connection.go` | Add `probeClient` to `connectionService` — a plain, uncached `*http.Client` (15s timeout) reserved for validation probes; set in `NewConnectionService`. |
| `nexus-broker/internal/service/credential.go` | `validateCredentials` now issues its probe via `validationClient()` instead of `httpClient`. New `validationClient()` returns `probeClient`, falling back to `httpClient` so existing tests that construct the service directly keep working; its doc comment records why probes must bypass the cache. |
| `nexus-broker/pkg/caching/client.go` | `cachingTransport.RoundTrip` passes credentialed requests straight to the underlying transport and never writes them to Redis. New `isCredentialed()` detects `Authorization`, `Proxy-Authorization`, cookies, and token-ish header names (`*api-key*`, `*apikey*`, `*token*`, `*secret*`) used by providers in place of `Authorization`. |
| `nexus-broker/internal/service/validation_cache_test.go` | New. `TestValidateCredentials_ProbeIsNeverCached` asserts one probe per attempt and that a bad credential is rejected after a good one succeeded on the same URL. `TestCachingTransport_DoesNotCacheCredentialedRequests` asserts basic/bearer/custom-header requests reach the origin every time. |

The second change is defence in depth and worth keeping on its own merits: storing
authenticated response **bodies** under a URL-only key in shared Redis risks
serving one caller's response to another.

## How to Test

Automated:

    cd nexus-broker
    go test ./internal/service/ ./pkg/caching/

Manual end-to-end (this is how the bug was found — the unit tests alone pass on
both the broken and fixed code paths):

1. Start dependencies and the broker:

       docker compose up -d postgres redis
       cd nexus-broker
       DATABASE_URL="postgres://<user>:<pass>@localhost:5432/<db>?sslmode=disable" \
         DB_SSLMODE=disable REDIS_URL="redis://localhost:6379" \
         BASE_URL="http://localhost:8080" go run ./cmd/nexus-broker

   Also run the gateway (`nexus-gateway`, `go run ./cmd/nexus-rest`, with
   `BROKER_BASE_URL=http://localhost:8080`).

2. Stand up a stub provider on `127.0.0.1:9999` that returns **200** for Basic
   `admin:token_good` on `/me/api/json` and **401** for anything else.

3. Register a self-hosted static provider (no `api_base_url`, so the instance URL
   comes from the user at connect time):

       curl -X POST http://localhost:8080/providers -H 'X-API-Key: <key>' \
         -H 'Content-Type: application/json' -d '{"profile":{
           "name":"e2e-jenkins","auth_type":"basic_auth",
           "user_info_endpoint":"/me/api/json",
           "params":{"credential_schema":{"type":"object",
             "required":["base_url","username","password"],
             "properties":{"base_url":{"type":"string"},
               "username":{"type":"string"},"password":{"type":"string"}}},
           "auth_strategy":{"type":"basic_auth","config":{
             "username_field":"username","password_field":"password"}}}}}'

4. `redis-cli FLUSHALL`, then for each attempt `POST /v1/request-connection` to
   get a `state` and `POST /v1/capture-credential` with
   `{"base_url":"http://127.0.0.1:9999","username":"admin","password":"<pw>"}`.

   Run in this order: **`token_good`, then `WRONG`, then `WRONG`, then
   `token_good`.**

**Before this change:** attempt 1 succeeds, attempt 2 also succeeds with the wrong
password, and the stub receives only **one** request — the rest are served from
cache. Reversing the order (`WRONG` first) makes the subsequent valid credential
fail for the rest of the TTL.

**After this change:** accept / reject / reject / accept, and the stub logs
**four** requests — one per attempt, in both directions.

## Migration / Breaking Changes

- [ ] Database migration required — include the migration file path
- [x] No migration required

No schema change (0 DDL statements in the diff), no config change, no API change.

One operational note: credentialed GETs issued through the caching client are no
longer served from Redis, so outbound requests to providers increase. For
credential validation that is the intended behaviour — each probe must reach the
provider. Unauthenticated GETs (OIDC discovery documents, JWKS), which are the
cache's legitimate use, are unaffected.

## Checklist
- [x] Code follows the Go styleguide (`gofmt` applied — clean on all four files)
- [x] Commit messages use present tense, imperative mood, ≤72 chars (subject is 70)
- [x] Documentation updated where applicable — no existing docs describe the caching client or the validation probe, so there is nothing to amend; the rationale lives in the `validationClient()` and `isCredentialed()` doc comments
- [x] No secrets or credentials committed

## Notes for the reviewer

Two judgement calls worth surfacing rather than burying:

- I did **not** tick "Breaking change". No API or schema shifts, but caching
  behaviour genuinely changes for any credentialed GET through that client.
  Today that is only the validation probe and OIDC discovery, so the blast
  radius is small — but anyone later routing provider data-plane calls through
  this client should not expect cache hits.
- `isCredentialed` header matching is heuristic (substring matches on `token`,
  `secret`, `api-key`). It errs toward *not* caching, which is the safe
  direction, but it will also skip caching for an unauthenticated endpoint that
  happens to carry such a header name.
